### PR TITLE
[Bugfix] Remove `throws` from parsing

### DIFF
--- a/extras/src/FromString.cpp
+++ b/extras/src/FromString.cpp
@@ -48,7 +48,9 @@ void setOps(T& exp, const std::unique_ptr<Oasis::Expression>& op1, const std::un
 bool processOp(std::stack<std::string>& ops, std::stack<std::unique_ptr<Oasis::Expression>>& st)
 {
     if (st.size() < 2) {
-        throw std::runtime_error("Invalid number of arguments");
+        // TODO: Pass error message up
+        // throw std::runtime_error("Invalid number of arguments");
+        return false;
     }
 
     const std::unique_ptr<Oasis::Expression> right = std::move(st.top());
@@ -101,7 +103,9 @@ bool processOp(std::stack<std::string>& ops, std::stack<std::unique_ptr<Oasis::E
 bool processFunction(std::stack<std::unique_ptr<Oasis::Expression>>& st, const std::string& function_token)
 {
     if (st.size() < 2) {
-        throw std::runtime_error("Invalid number of arguments");
+        // TODO: Pass error message up
+        // throw std::runtime_error("Invalid number of arguments");
+        return false;
     }
 
     // If we have a function active, the second operand has just been pushed onto the stack
@@ -263,7 +267,7 @@ auto FromInFix(const std::string& str) -> ParseResult {
             // function_active = true;
             while (!ops.empty() && ops.top() != "(") {
                 if (!processOp(ops, st)) {
-                    return ParseResult { fmt::format(R"(Unknown operator: "{}")", token) };
+                    return ParseResult { fmt::format(R"(Unknown operator: "{}, or invalid number of operands")", token) };
                 }
             }
         }
@@ -271,12 +275,12 @@ auto FromInFix(const std::string& str) -> ParseResult {
         else if (token == ")") {
             while (!ops.empty() && ops.top() != "(") {
                 if (!processOp(ops, st)) {
-                    return ParseResult { fmt::format(R"(Unknown operator: "{}")", token) };
+                    return ParseResult { fmt::format(R"(Unknown operator: "{}, or invalid number of operands")", token) };
                 }
             }
 
             if (ops.empty() || ops.top() != "(") {
-                throw std::runtime_error("Mismatched parenthesis");
+                return ParseResult { "Mismatched parenthesis" };
             }
 
             ops.pop(); // pop '('


### PR DESCRIPTION
Modified `processOp` and `processFunction` to return `false` instead of throwing exceptions on invalid argument counts. This ensures errors are passed up properly, and updated error messages to reflect changes.