### PR TITLE
[Feature] Introduce `MatchCast`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(Catch2 fmt)
 
+include(cmake/FetchBoost.cmake)
 include(cmake/FetchEigen.cmake)
 include(cmake/FetchTinyxml2.cmake)
 

--- a/cmake/FetchBoost.cmake
+++ b/cmake/FetchBoost.cmake
@@ -1,0 +1,10 @@
+FetchContent_Declare(
+        Boost
+        URL https://github.com/boostorg/boost/releases/download/boost-1.84.0/boost-1.84.0.tar.xz
+        URL_MD5 893b5203b862eb9bbd08553e24ff146a
+        DOWNLOAD_EXTRACT_TIMESTAMP ON
+        EXCLUDE_FROM_ALL
+)
+
+set(BOOST_INCLUDE_LIBRARIES mpl)
+FetchContent_MakeAvailable(Boost)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -14,6 +14,7 @@ set(Oasis_HEADERS
     Oasis/Linear.hpp
     Oasis/Log.hpp
     Oasis/Magnitude.hpp
+    Oasis/MatchCast.hpp
     Oasis/Multiply.hpp
     Oasis/Negate.hpp
     Oasis/Pi.hpp

--- a/include/Oasis/MatchCast.hpp
+++ b/include/Oasis/MatchCast.hpp
@@ -30,7 +30,7 @@ public:
     MatchCast& Case(Lambda caseTrueCallback)
     {
         using ArgType = lambda_argument_type<Lambda>;
-        cases_.emplace_back([this, caseTrueCallback](const ArgumentT& arg_) -> std::unique_ptr<ArgumentT> {
+        cases_.emplace_back([caseTrueCallback](const ArgumentT& arg_) -> std::unique_ptr<ArgumentT> {
             if (std::unique_ptr<ArgType> castResult = RecursiveCast<ArgType>(arg_)) return caseTrueCallback(*castResult);
             return {};
         });

--- a/include/Oasis/MatchCast.hpp
+++ b/include/Oasis/MatchCast.hpp
@@ -23,15 +23,16 @@ using lambda_argument_type = typename lambda_traits<decltype(&Lambda::operator()
 
 template <typename ArgumentT>
 class MatchCast {
-public:
+
     using CaseFuncT = std::function<std::unique_ptr<ArgumentT>(const ArgumentT&)>;
 
+public:
     template<typename Lambda>
     MatchCast& Case(Lambda caseTrueCallback)
     {
-        using ArgType = lambda_argument_type<Lambda>;
+        using CaseType = lambda_argument_type<Lambda>;
         cases_.emplace_back([caseTrueCallback](const ArgumentT& arg_) -> std::unique_ptr<ArgumentT> {
-            if (std::unique_ptr<ArgType> castResult = RecursiveCast<ArgType>(arg_)) return caseTrueCallback(*castResult);
+            if (std::unique_ptr<CaseType> castResult = RecursiveCast<CaseType>(arg_)) return caseTrueCallback(*castResult);
             return {};
         });
 

--- a/include/Oasis/MatchCast.hpp
+++ b/include/Oasis/MatchCast.hpp
@@ -5,18 +5,33 @@
 #ifndef OASIS_MATCHCAST_HPP
 #define OASIS_MATCHCAST_HPP
 
+#include <type_traits>
+#include <functional>
+
 namespace Oasis {
+
+template <typename T>
+struct lambda_traits;
+
+template <typename Ret, typename ClassType, typename Arg>
+struct lambda_traits<Ret(ClassType::*)(Arg) const> {
+    using argument_type = std::remove_cvref_t<Arg>;
+};
+
+template <typename Lambda>
+using lambda_argument_type = typename lambda_traits<decltype(&Lambda::operator())>::argument_type;
 
 template <typename ArgumentT>
 class MatchCast {
 public:
     using CaseFuncT = std::function<std::unique_ptr<ArgumentT>(const ArgumentT&)>;
 
-    template<typename T>
-    MatchCast& Case(std::function<std::unique_ptr<ArgumentT>(const T&)> caseTrueCallback)
+    template<typename Lambda>
+    MatchCast& Case(Lambda caseTrueCallback)
     {
+        using ArgType = lambda_argument_type<Lambda>;
         cases_.emplace_back([this, caseTrueCallback](const ArgumentT& arg_) -> std::unique_ptr<ArgumentT> {
-            if (std::unique_ptr<T> castResult = RecursiveCast<T>(arg_)) return caseTrueCallback(*castResult);
+            if (std::unique_ptr<ArgType> castResult = RecursiveCast<ArgType>(arg_)) return caseTrueCallback(*castResult);
             return {};
         });
 

--- a/include/Oasis/MatchCast.hpp
+++ b/include/Oasis/MatchCast.hpp
@@ -2,11 +2,27 @@
 // Created by Matthew McCall on 10/22/24.
 //
 
+
+// Hear ye, valiant coder! Within this hallowed script of Oasis' MatchCast,
+// lies an unfathomable confluence of templated magic, scarcely understood only by even the
+// most exalted compilers and the divine overseers. This arcane construct,
+// when tampered with, may envelop thee in utter confusion, leaving thee solitary in thy pursuits.
+// Of course, this sagely advice surely does not emanate from a mere language model. Rather, 
+// it is the timeless counsel of battle-hardened developers who have faced such arcane complexity.
+// Should regret cloud thy mind and thou desires to undo thine alterations, perform the following
+// sacred rite to restore the code to its pristine state:
+// 
+// git checkout -- <path_to_this_file>
+//
+
 #ifndef OASIS_MATCHCAST_HPP
 #define OASIS_MATCHCAST_HPP
 
+#include <boost/mpl/vector.hpp>
+#include <boost/mpl/for_each.hpp>
+#include <boost/mpl/push_back.hpp>
+
 #include <functional>
-#include <type_traits>
 
 namespace Oasis {
 
@@ -21,36 +37,31 @@ struct lambda_traits<Ret (ClassType::*)(Arg) const> {
 template <typename Lambda>
 using lambda_argument_type = typename lambda_traits<decltype(&Lambda::operator())>::argument_type;
 
-template <typename ArgumentT>
-class MatchCast {
-
-    using CaseFuncT = std::function<std::unique_ptr<ArgumentT>(const ArgumentT&)>;
-
+template <typename ArgumentT, typename Cases>
+class MatchCastImpl {
 public:
     template <typename Lambda>
-    MatchCast& Case(Lambda caseTrueCallback)
+    MatchCastImpl<ArgumentT, typename boost::mpl::push_back<Cases, Lambda>::type>
+    Case(Lambda) const
     {
-        using CaseType = lambda_argument_type<Lambda>;
-        cases_.emplace_back([caseTrueCallback](const ArgumentT& arg_) -> std::unique_ptr<ArgumentT> {
-            if (std::unique_ptr<CaseType> castResult = RecursiveCast<CaseType>(arg_))
-                return caseTrueCallback(*castResult);
-            return {};
-        });
-
-        return *this;
+        return MatchCastImpl<ArgumentT, typename boost::mpl::push_back<Cases, Lambda>::type>();
     }
 
     std::unique_ptr<ArgumentT> Execute(const ArgumentT& arg, std::unique_ptr<ArgumentT>&& fallback) const
     {
-        for (const auto& c : cases_)
-            if (auto result = c(arg))
-                return result;
-        return fallback;
+        std::unique_ptr<ArgumentT> result = nullptr;
+        boost::mpl::for_each<Cases>([&]<typename CaseTrueCallbackT>(CaseTrueCallbackT caseTrueCallback) {
+            using CaseType = lambda_argument_type<CaseTrueCallbackT>;
+            if (result) return;
+            if (std::unique_ptr<CaseType> castResult = RecursiveCast<CaseType>(arg))
+                result = caseTrueCallback(*castResult);
+        });
+        return result ? std::move(result) : std::move(fallback);
     }
-
-private:
-    std::vector<CaseFuncT> cases_;
 };
+
+template <typename ArgumentT>
+using MatchCast = MatchCastImpl<ArgumentT, boost::mpl::vector<>>;
 
 }
 

--- a/include/Oasis/MatchCast.hpp
+++ b/include/Oasis/MatchCast.hpp
@@ -1,0 +1,38 @@
+//
+// Created by Matthew McCall on 10/22/24.
+//
+
+#ifndef OASIS_MATCHCAST_HPP
+#define OASIS_MATCHCAST_HPP
+
+namespace Oasis {
+
+template <typename ArgumentT>
+class MatchCast {
+public:
+    using CaseFuncT = std::function<std::unique_ptr<ArgumentT>(const ArgumentT&)>;
+
+    template<typename T>
+    MatchCast& Case(std::function<std::unique_ptr<ArgumentT>(const T&)> caseTrueCallback)
+    {
+        cases_.emplace_back([this, caseTrueCallback](const ArgumentT& arg_) -> std::unique_ptr<ArgumentT> {
+            if (std::unique_ptr<T> castResult = RecursiveCast<T>(arg_)) return caseTrueCallback(*castResult);
+            return {};
+        });
+
+        return *this;
+    }
+
+    std::unique_ptr<ArgumentT> Execute(const ArgumentT& arg, std::unique_ptr<ArgumentT>&& fallback) const
+    {
+        for (const auto& c : cases_) if (auto result = c(arg)) return result;
+        return fallback;
+    }
+
+private:
+    std::vector<CaseFuncT> cases_;
+};
+
+}
+
+#endif //OASIS_MATCHCAST_HPP

--- a/include/Oasis/MatchCast.hpp
+++ b/include/Oasis/MatchCast.hpp
@@ -2,25 +2,24 @@
 // Created by Matthew McCall on 10/22/24.
 //
 
-
 // Hear ye, valiant coder! Within this hallowed script of Oasis' MatchCast,
 // lies an unfathomable confluence of templated magic, scarcely understood only by even the
 // most exalted compilers and the divine overseers. This arcane construct,
 // when tampered with, may envelop thee in utter confusion, leaving thee solitary in thy pursuits.
-// Of course, this sagely advice surely does not emanate from a mere language model. Rather, 
+// Of course, this sagely advice surely does not emanate from a mere language model. Rather,
 // it is the timeless counsel of battle-hardened developers who have faced such arcane complexity.
 // Should regret cloud thy mind and thou desires to undo thine alterations, perform the following
 // sacred rite to restore the code to its pristine state:
-// 
+//
 // git checkout -- <path_to_this_file>
 //
 
 #ifndef OASIS_MATCHCAST_HPP
 #define OASIS_MATCHCAST_HPP
 
-#include <boost/mpl/vector.hpp>
 #include <boost/mpl/for_each.hpp>
 #include <boost/mpl/push_back.hpp>
+#include <boost/mpl/vector.hpp>
 
 #include <functional>
 
@@ -52,7 +51,8 @@ public:
         std::unique_ptr<ArgumentT> result = nullptr;
         boost::mpl::for_each<Cases>([&]<typename CaseTrueCallbackT>(CaseTrueCallbackT caseTrueCallback) {
             using CaseType = lambda_argument_type<CaseTrueCallbackT>;
-            if (result) return;
+            if (result)
+                return;
             if (std::unique_ptr<CaseType> castResult = RecursiveCast<CaseType>(arg))
                 result = caseTrueCallback(*castResult);
         });

--- a/include/Oasis/MatchCast.hpp
+++ b/include/Oasis/MatchCast.hpp
@@ -5,8 +5,8 @@
 #ifndef OASIS_MATCHCAST_HPP
 #define OASIS_MATCHCAST_HPP
 
-#include <type_traits>
 #include <functional>
+#include <type_traits>
 
 namespace Oasis {
 
@@ -14,7 +14,7 @@ template <typename T>
 struct lambda_traits;
 
 template <typename Ret, typename ClassType, typename Arg>
-struct lambda_traits<Ret(ClassType::*)(Arg) const> {
+struct lambda_traits<Ret (ClassType::*)(Arg) const> {
     using argument_type = std::remove_cvref_t<Arg>;
 };
 
@@ -27,12 +27,13 @@ class MatchCast {
     using CaseFuncT = std::function<std::unique_ptr<ArgumentT>(const ArgumentT&)>;
 
 public:
-    template<typename Lambda>
+    template <typename Lambda>
     MatchCast& Case(Lambda caseTrueCallback)
     {
         using CaseType = lambda_argument_type<Lambda>;
         cases_.emplace_back([caseTrueCallback](const ArgumentT& arg_) -> std::unique_ptr<ArgumentT> {
-            if (std::unique_ptr<CaseType> castResult = RecursiveCast<CaseType>(arg_)) return caseTrueCallback(*castResult);
+            if (std::unique_ptr<CaseType> castResult = RecursiveCast<CaseType>(arg_))
+                return caseTrueCallback(*castResult);
             return {};
         });
 
@@ -41,7 +42,9 @@ public:
 
     std::unique_ptr<ArgumentT> Execute(const ArgumentT& arg, std::unique_ptr<ArgumentT>&& fallback) const
     {
-        for (const auto& c : cases_) if (auto result = c(arg)) return result;
+        for (const auto& c : cases_)
+            if (auto result = c(arg))
+                return result;
         return fallback;
     }
 
@@ -51,4 +54,4 @@ private:
 
 }
 
-#endif //OASIS_MATCHCAST_HPP
+#endif // OASIS_MATCHCAST_HPP

--- a/src/Add.cpp
+++ b/src/Add.cpp
@@ -8,6 +8,7 @@
 #include "Oasis/Imaginary.hpp"
 #include "Oasis/Integral.hpp"
 #include "Oasis/Log.hpp"
+#include "Oasis/MatchCast.hpp"
 #include "Oasis/Matrix.hpp"
 #include "Oasis/Multiply.hpp"
 #include "Oasis/RecursiveCast.hpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,6 @@ if(OASIS_BUILD_PARANOID)
 endif()
 
 target_compile_features(Oasis PUBLIC cxx_std_20)
-target_link_libraries(Oasis PUBLIC Oasis::Headers Eigen3::Eigen)
+target_link_libraries(Oasis PUBLIC Oasis::Headers Eigen3::Eigen Boost::mpl)
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${Oasis_SOURCES})

--- a/src/Exponent.cpp
+++ b/src/Exponent.cpp
@@ -19,76 +19,77 @@
 namespace Oasis {
 
 Exponent<Expression>::Exponent(const Expression& base, const Expression& power)
-    : BinaryExpression(base, power) {}
+    : BinaryExpression(base, power)
+{
+}
 
 auto Exponent<Expression>::Simplify() const -> std::unique_ptr<Expression>
 {
-    static auto match_cast =
-        MatchCast<Expression>()
-        .Case([](const Exponent<Expression, Real>& zeroCase) -> std::unique_ptr<Expression> {
-            if (const Real& power = zeroCase.GetLeastSigOp(); power.GetValue() == 0.0)
-                return std::make_unique<Real>(1.0);
-            return {};
-        })
-        .Case([](const Exponent<Real, Expression>& zeroCase) -> std::unique_ptr<Expression> {
-            if (const Real& base = zeroCase.GetMostSigOp(); base.GetValue() == 0.0)
-                return std::make_unique<Real>(0.0);
-            return {};
-        })
-        .Case([](const Exponent<Real>& realCase) -> std::unique_ptr<Expression> {
-            const Real& base = realCase.GetMostSigOp();
-            const Real& power = realCase.GetLeastSigOp();
-            return std::make_unique<Real>(pow(base.GetValue(), power.GetValue()));
-        })
-        .Case([](const Exponent<Expression, Real>& oneCase) -> std::unique_ptr<Expression> {
-            if (const Real& power = oneCase.GetLeastSigOp(); power.GetValue() == 1.0)
-                return oneCase.GetMostSigOp().Copy();
-            return {};
-        })
-        .Case([](const Exponent<Real, Expression>& oneCase) -> std::unique_ptr<Expression> {
-            if (const Real& base = oneCase.GetMostSigOp(); base.GetValue() == 1.0)
-                return std::make_unique<Real>(1.0);
-            return {};
-        })
-        .Case([](const Exponent<Imaginary, Real>& ImgCase) -> std::unique_ptr<Expression> {
-            const auto power = std::fmod((ImgCase.GetLeastSigOp()).GetValue(), 4);
-            switch (static_cast<int>(power)) {
-            case 0:
-                return std::make_unique<Real>(1);
-            case 1:
-                return std::make_unique<Imaginary>();
-            case 2:
-                return std::make_unique<Real>(-1);
-            case 3:
-                return std::make_unique<Multiply<Real, Imaginary>>(Real{ -1 }, Imaginary{});
-            default:
-                return {};
-            }
-        })
-        .Case([](const Exponent<Multiply<Real, Expression>, Real>& ImgCase) -> std::unique_ptr<Expression> {
-            if (ImgCase.GetMostSigOp().GetMostSigOp().GetValue() < 0 && ImgCase.GetLeastSigOp().GetValue() == 0.5) {
-                return std::make_unique<Multiply<>>(
-                    Multiply{ Real{ pow(std::abs(ImgCase.GetMostSigOp().GetMostSigOp().GetValue()), 0.5) },
-                              Exponent{ ImgCase.GetMostSigOp().GetLeastSigOp(), Real{ 0.5 } } },
-                    Imaginary{});
-            }
-            return {};
-        })
-        .Case([](const Exponent<Exponent, Expression>& expExpCase) -> std::unique_ptr<Expression> {
-            return std::make_unique<Exponent>(expExpCase.GetMostSigOp().GetMostSigOp(),
-                *(Multiply{ expExpCase.GetMostSigOp().GetLeastSigOp(), expExpCase.GetLeastSigOp() }.Simplify()));
-        })
-        .Case([](const Exponent<Expression, Log<>>& logCase) -> std::unique_ptr<Expression> {
-            if (logCase.GetMostSigOp().Equals(logCase.GetLeastSigOp().GetMostSigOp())) {
-                return logCase.GetLeastSigOp().GetLeastSigOp().Copy();
-            }
-            return {};
-        });
+    static auto match_cast = MatchCast<Expression>()
+                                 .Case([](const Exponent<Expression, Real>& zeroCase) -> std::unique_ptr<Expression> {
+                                     if (const Real& power = zeroCase.GetLeastSigOp(); power.GetValue() == 0.0)
+                                         return std::make_unique<Real>(1.0);
+                                     return {};
+                                 })
+                                 .Case([](const Exponent<Real, Expression>& zeroCase) -> std::unique_ptr<Expression> {
+                                     if (const Real& base = zeroCase.GetMostSigOp(); base.GetValue() == 0.0)
+                                         return std::make_unique<Real>(0.0);
+                                     return {};
+                                 })
+                                 .Case([](const Exponent<Real>& realCase) -> std::unique_ptr<Expression> {
+                                     const Real& base = realCase.GetMostSigOp();
+                                     const Real& power = realCase.GetLeastSigOp();
+                                     return std::make_unique<Real>(pow(base.GetValue(), power.GetValue()));
+                                 })
+                                 .Case([](const Exponent<Expression, Real>& oneCase) -> std::unique_ptr<Expression> {
+                                     if (const Real& power = oneCase.GetLeastSigOp(); power.GetValue() == 1.0)
+                                         return oneCase.GetMostSigOp().Copy();
+                                     return {};
+                                 })
+                                 .Case([](const Exponent<Real, Expression>& oneCase) -> std::unique_ptr<Expression> {
+                                     if (const Real& base = oneCase.GetMostSigOp(); base.GetValue() == 1.0)
+                                         return std::make_unique<Real>(1.0);
+                                     return {};
+                                 })
+                                 .Case([](const Exponent<Imaginary, Real>& ImgCase) -> std::unique_ptr<Expression> {
+                                     const auto power = std::fmod((ImgCase.GetLeastSigOp()).GetValue(), 4);
+                                     switch (static_cast<int>(power)) {
+                                     case 0:
+                                         return std::make_unique<Real>(1);
+                                     case 1:
+                                         return std::make_unique<Imaginary>();
+                                     case 2:
+                                         return std::make_unique<Real>(-1);
+                                     case 3:
+                                         return std::make_unique<Multiply<Real, Imaginary>>(Real { -1 }, Imaginary {});
+                                     default:
+                                         return {};
+                                     }
+                                 })
+                                 .Case([](const Exponent<Multiply<Real, Expression>, Real>& ImgCase) -> std::unique_ptr<Expression> {
+                                     if (ImgCase.GetMostSigOp().GetMostSigOp().GetValue() < 0 && ImgCase.GetLeastSigOp().GetValue() == 0.5) {
+                                         return std::make_unique<Multiply<>>(
+                                             Multiply { Real { pow(std::abs(ImgCase.GetMostSigOp().GetMostSigOp().GetValue()), 0.5) },
+                                                 Exponent { ImgCase.GetMostSigOp().GetLeastSigOp(), Real { 0.5 } } },
+                                             Imaginary {});
+                                     }
+                                     return {};
+                                 })
+                                 .Case([](const Exponent<Exponent, Expression>& expExpCase) -> std::unique_ptr<Expression> {
+                                     return std::make_unique<Exponent>(expExpCase.GetMostSigOp().GetMostSigOp(),
+                                         *(Multiply { expExpCase.GetMostSigOp().GetLeastSigOp(), expExpCase.GetLeastSigOp() }.Simplify()));
+                                 })
+                                 .Case([](const Exponent<Expression, Log<>>& logCase) -> std::unique_ptr<Expression> {
+                                     if (logCase.GetMostSigOp().Equals(logCase.GetLeastSigOp().GetMostSigOp())) {
+                                         return logCase.GetLeastSigOp().GetLeastSigOp().Copy();
+                                     }
+                                     return {};
+                                 });
 
     const auto simplifiedBase = mostSigOp->Simplify();
     const auto simplifiedPower = leastSigOp->Simplify();
 
-    const Exponent simplifiedExponent{ *simplifiedBase, *simplifiedPower };
+    const Exponent simplifiedExponent { *simplifiedBase, *simplifiedPower };
 
     return match_cast.Execute(simplifiedExponent, simplifiedExponent.Copy());
 }
@@ -107,11 +108,11 @@ auto Exponent<Expression>::Integrate(const Expression& integrationVariable) cons
 
             if ((*variable).GetName() == expBase.GetName()) {
 
-                Add adder{
-                    Divide{
-                        Exponent<Variable, Real>{ Variable{ (*variable).GetName() }, Real{ expPow.GetValue() + 1 } },
-                        Real{ expPow.GetValue() + 1 } },
-                    Variable{ "C" }
+                Add adder {
+                    Divide {
+                        Exponent<Variable, Real> { Variable { (*variable).GetName() }, Real { expPow.GetValue() + 1 } },
+                        Real { expPow.GetValue() + 1 } },
+                    Variable { "C" }
                 };
 
                 return adder.Simplify();
@@ -119,7 +120,7 @@ auto Exponent<Expression>::Integrate(const Expression& integrationVariable) cons
         }
     }
 
-    Integral<Expression, Expression> integral{ *(this->Copy()), *(integrationVariable.Copy()) };
+    Integral<Expression, Expression> integral { *(this->Copy()), *(integrationVariable.Copy()) };
 
     return integral.Copy();
 }
@@ -137,33 +138,33 @@ auto Exponent<Expression>::Differentiate(const Expression& differentiationVariab
             const Real& expPow = realExponent->GetLeastSigOp();
 
             if (variable->GetName() == expBase.GetName()) {
-                return Multiply{
-                        Real{ expPow.GetValue() },
-                        Exponent{
-                            Variable{ variable->GetName() },
-                            Real{ expPow.GetValue() - 1 } }
-                    }
+                return Multiply {
+                    Real { expPow.GetValue() },
+                    Exponent {
+                        Variable { variable->GetName() },
+                        Real { expPow.GetValue() - 1 } }
+                }
                     .Simplify();
             }
         }
 
         if (auto natBase = RecursiveCast<Exponent<EulerNumber, Expression>>(*simplifiedExponent); natBase != nullptr) {
-            Multiply derivative{ Derivative{ natBase->GetLeastSigOp(), differentiationVariable }, *simplifiedExponent };
+            Multiply derivative { Derivative { natBase->GetLeastSigOp(), differentiationVariable }, *simplifiedExponent };
             return derivative.Simplify();
         }
 
         if (auto realBase = RecursiveCast<Exponent<Real, Expression>>(*simplifiedExponent); realBase != nullptr) {
-            Multiply derivative{ Multiply{ Derivative{ realBase->GetLeastSigOp(), differentiationVariable }, *simplifiedExponent }, Log{ EulerNumber{}, realBase->GetMostSigOp() } };
+            Multiply derivative { Multiply { Derivative { realBase->GetLeastSigOp(), differentiationVariable }, *simplifiedExponent }, Log { EulerNumber {}, realBase->GetMostSigOp() } };
             return derivative.Simplify();
         }
 
         if (auto varBase = RecursiveCast<Exponent<Variable, Expression>>(*simplifiedExponent); varBase != nullptr) {
-            Multiply derivative{ Multiply{ Derivative{ varBase->GetLeastSigOp(), differentiationVariable }, *simplifiedExponent }, Log{ EulerNumber{}, varBase->GetMostSigOp() } };
+            Multiply derivative { Multiply { Derivative { varBase->GetLeastSigOp(), differentiationVariable }, *simplifiedExponent }, Log { EulerNumber {}, varBase->GetMostSigOp() } };
             return derivative.Simplify();
         }
     }
 
-    return Derivative{ *this, differentiationVariable }.Copy();
+    return Derivative { *this, differentiationVariable }.Copy();
 }
 
 } // Oasis

--- a/src/Exponent.cpp
+++ b/src/Exponent.cpp
@@ -28,7 +28,7 @@ auto Exponent<Expression>::Simplify() const -> std::unique_ptr<Expression>
 
     const Exponent simplifiedExponent{ *simplifiedBase, *simplifiedPower };
 
-    return MatchCast<Expression>()
+    static auto matchcast = MatchCast<Expression>()
            .Case<Exponent<Expression, Real>>([](const auto& zeroCase) -> std::unique_ptr<Expression> {
                if (const Real& power = zeroCase.GetLeastSigOp(); power.GetValue() == 0.0)
                    return std::make_unique<Real>(1.0);
@@ -87,8 +87,9 @@ auto Exponent<Expression>::Simplify() const -> std::unique_ptr<Expression>
                    return logCase.GetLeastSigOp().GetLeastSigOp().Copy();
                }
                return {};
-           })
-           .Execute(simplifiedExponent, simplifiedExponent.Copy());
+           });
+
+    return matchcast.Execute(simplifiedExponent, simplifiedExponent.Copy());
 }
 
 auto Exponent<Expression>::Integrate(const Expression& integrationVariable) const -> std::unique_ptr<Expression>


### PR DESCRIPTION
This pull request introduces the `MatchCast` utility and integrates Boost libraries into the project. The key changes involve adding the `MatchCast` header, updating CMake configurations to fetch and link Boost, and refactoring the `Exponent` class to use `MatchCast`.

### Integration of Boost Libraries:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR40): Included `FetchBoost.cmake` to fetch Boost libraries.
* [`cmake/FetchBoost.cmake`](diffhunk://#diff-78f6dc9d41e80abf82d348c73abfd80426b371a004cb1581ee114a320ccffef8R1-R10): Added script to fetch and configure Boost library.
* [`src/CMakeLists.txt`](diffhunk://#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4L46-R46): Updated to link Boost::mpl library.

### Introduction of `MatchCast`:

* [`include/Oasis/MatchCast.hpp`](diffhunk://#diff-b85575077f3ec76e5741096c7421ca0fbdb05ca521b57b03edf723691a9cfd63R1-R68): Added new header for `MatchCast` utility.
* [`include/CMakeLists.txt`](diffhunk://#diff-f15f7409d37485ed889fc8730c1f63d6570e55cfb27a4ee9dc7760014a79a739R17): Included `Oasis/MatchCast.hpp` in the project headers.
* `src/Add.cpp`, `src/Exponent.cpp`: Updated to include `Oasis/MatchCast.hpp`. [[1]](diffhunk://#diff-b0720a6c28687a4e86b8ea6492b6386ad93c05c540238ad195075ecba7f9a205R11) [[2]](diffhunk://#diff-1e94e5d49738010c412d8b87d0f6ba36a8cde1ec6a9e82688aba0026bcc6d3fdR15)

### Refactoring of `Exponent` Class:

* [`src/Exponent.cpp`](diffhunk://#diff-1e94e5d49738010c412d8b87d0f6ba36a8cde1ec6a9e82688aba0026bcc6d3fdL27-R94): Refactored `Exponent<Expression>::Simplify` method to use `MatchCast` for cleaner and more maintainable code.