### PR TITLE
[Feature] Run Linux workflow in a container and add Windows-specific build workflow

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
     build_and_test:
-        runs-on: ${{ matrix.os }}
+        runs-on: ubuntu-latest
         container: ghcr.io/open-algebra/gh-actions:main
 
         strategy:
@@ -28,29 +28,14 @@ jobs:
             # Due to a bug in GCC (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111485), building with GCC is disabled.
             matrix:
                 build_type: [ Release, Debug ]
-                c_compiler: [ gcc, clang-17, cl ]
+                c_compiler: [ gcc, clang-17 ]
 
                 include:
-                  - os: ubuntu-latest
-                    c_compiler: gcc
+                  - c_compiler: gcc
                     cpp_compiler: g++
-                  - os: ubuntu-latest
-                    c_compiler: clang-17
+                  - c_compiler: clang-17
                     cpp_compiler: clang++-17
                     build_profiling: true
-                  # - os: windows-latest
-                  #   c_comiler: gcc
-                  #   cpp_compiler: g++
-                  - os: windows-latest
-                    c_compiler: cl
-                    cpp_compiler: cl
-                exclude:
-                  - os: ubuntu-latest
-                    c_compiler: cl
-                  - os: windows-latest
-                    c_compiler: clang-17
-                  - os: windows-latest
-                    c_compiler: gcc
         steps:
             # Checks out the repository.
           - name: Checkout repository

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -45,9 +45,9 @@ jobs:
             id: strings
             shell: bash
             run: |
-              echo "build-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
-              echo "coverage-dir=${{ github.workspace }}/coverage" >> "$GITHUB_OUTPUT"
-              echo "pr-dir=${{ github.workspace }}/pr" >> "$GITHUB_OUTPUT"
+              echo "build-dir=$(pwd)/build" >> "$GITHUB_OUTPUT"
+              echo "coverage-dir=$(pwd)/coverage" >> "$GITHUB_OUTPUT"
+              echo "pr-dir=$(pwd)/pr" >> "$GITHUB_OUTPUT"
 
             # Saves the PR number to use in writing a comment on the PR.
           - name: Save PR number
@@ -68,13 +68,13 @@ jobs:
             run: >
                 cmake
                 -B ${{ steps.strings.outputs.build-dir }}
-                -S ${{ github.workspace }}
                 -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
                 -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
                 -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
                 -DOASIS_BUILD_IO=ON
                 -DOASIS_BUILD_WITH_COVERAGE=${{ matrix.build_profiling == true && 'ON' || 'OFF'}}
                 -DOASIS_BUILD_PARANOID=ON
+                .
 
             # Builds Oasis with the given configuration.
           - name: Build Oasis
@@ -118,12 +118,12 @@ jobs:
             shell: bash
             run: |
               llvm-profdata-17 merge -sparse oasis.profraw -o oasis.profdata
-              llvm-cov-17 show -output-dir reports -instr-profile oasis.profdata ${{ steps.strings.outputs.build-dir }}/tests/OasisTests -sources ${{ github.workspace }}/src ${{ github.workspace }}/include
+              llvm-cov-17 show -output-dir reports -instr-profile oasis.profdata ${{ steps.strings.outputs.build-dir }}/tests/OasisTests -sources ./src ./include
 
           - name: Memory Check
             working-directory: ${{ steps.strings.outputs.build-dir }}
             run: >
-              ${{ github.workspace }}/valgrind/bin/valgrind --leak-check=full --error-exitcode=1 ./tests/OasisTests
+              valgrind --leak-check=full --error-exitcode=1 ./tests/OasisTests
 
             # Uploads the build, test, and code coverage artifacts.
           - name: Upload artifacts

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -28,13 +28,13 @@ jobs:
             # Due to a bug in GCC (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111485), building with GCC is disabled.
             matrix:
                 build_type: [ Release, Debug ]
-                c_compiler: [ gcc, clang-17 ]
+                c_compiler: [ gcc, clang ]
 
                 include:
                   - c_compiler: gcc
                     cpp_compiler: g++
-                  - c_compiler: clang-17
-                    cpp_compiler: clang++-17
+                  - c_compiler: clang
+                    cpp_compiler: clang++
                     build_profiling: true
         steps:
             # Checks out the repository.
@@ -54,14 +54,6 @@ jobs:
             run: |
               mkdir -p ${{ steps.strings.outputs.pr-dir }}
               echo "${{ github.event.number }}" > ${{ steps.strings.outputs.pr-dir }}/issue_number
-
-            # Installs LLVM 17 on the Ubuntu runner.
-          - name: Install LLVM 17
-            if: ${{ matrix.c_compiler == 'clang-17' }}
-            run: |
-                wget https://apt.llvm.org/llvm.sh
-                chmod +x llvm.sh
-                sudo ./llvm.sh 17
 
             # Configures CMake in a subdirectory.
           - name: Configure CMake
@@ -117,8 +109,8 @@ jobs:
             working-directory: ${{ steps.strings.outputs.coverage-dir }}
             shell: bash
             run: |
-              llvm-profdata-17 merge -sparse oasis.profraw -o oasis.profdata
-              llvm-cov-17 show -output-dir reports -instr-profile oasis.profdata ${{ steps.strings.outputs.build-dir }}/tests/OasisTests -sources ./src ./include
+              llvm-profdata merge -sparse oasis.profraw -o oasis.profdata
+              llvm-cov show -output-dir reports -instr-profile oasis.profdata ${{ steps.strings.outputs.build-dir }}/tests/OasisTests -sources ./src ./include
 
           - name: Memory Check
             working-directory: ${{ steps.strings.outputs.build-dir }}

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -19,24 +19,28 @@ concurrency:
 jobs:
     build_and_test:
         runs-on: ${{ matrix.os }}
+        container: ghcr.io/open-algebra/gh-actions:main
 
         strategy:
             # Sets fail-fast to false to ensure that feedback is delivered for all platforms.
             fail-fast: false
 
+            # Due to a bug in GCC (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111485), building with GCC is disabled.
             matrix:
-                os: [ ubuntu-latest, windows-latest ]
                 build_type: [ Release, Debug ]
-                c_compiler: [ gcc-12, clang-17, cl ]
+                c_compiler: [ gcc, clang-17, cl ]
 
                 include:
                   - os: ubuntu-latest
-                    c_compiler: gcc-12
-                    cpp_compiler: g++-12
+                    c_compiler: gcc
+                    cpp_compiler: g++
                   - os: ubuntu-latest
                     c_compiler: clang-17
                     cpp_compiler: clang++-17
                     build_profiling: true
+                  # - os: windows-latest
+                  #   c_comiler: gcc
+                  #   cpp_compiler: g++
                   - os: windows-latest
                     c_compiler: cl
                     cpp_compiler: cl
@@ -46,7 +50,7 @@ jobs:
                   - os: windows-latest
                     c_compiler: clang-17
                   - os: windows-latest
-                    c_compiler: gcc-12
+                    c_compiler: gcc
         steps:
             # Checks out the repository.
           - name: Checkout repository
@@ -73,24 +77,6 @@ jobs:
                 wget https://apt.llvm.org/llvm.sh
                 chmod +x llvm.sh
                 sudo ./llvm.sh 17
-
-          - name: Install GCC 12
-            if: ${{ matrix.c_compiler == 'gcc-12' }}
-            run: |
-              sudo apt-get update
-              sudo apt-get install -y gcc-12
-
-          - name: Install Valgrind
-            if: ${{ matrix.os == 'ubuntu-latest' }}
-            run: |
-              sudo apt-get update && sudo apt install libc6-dbg
-              wget https://sourceware.org/pub/valgrind/valgrind-3.23.0.tar.bz2
-              tar -xf valgrind-3.23.0.tar.bz2
-              rm valgrind-3.23.0.tar.bz2
-              cd valgrind-*
-              ./configure --prefix=${{ github.workspace }}/valgrind
-              make
-              make install
 
             # Configures CMake in a subdirectory.
           - name: Configure CMake
@@ -150,7 +136,6 @@ jobs:
               llvm-cov-17 show -output-dir reports -instr-profile oasis.profdata ${{ steps.strings.outputs.build-dir }}/tests/OasisTests -sources ${{ github.workspace }}/src ${{ github.workspace }}/include
 
           - name: Memory Check
-            if: ${{ matrix.os == 'ubuntu-latest' }}
             working-directory: ${{ steps.strings.outputs.build-dir }}
             run: >
               ${{ github.workspace }}/valgrind/bin/valgrind --leak-check=full --error-exitcode=1 ./tests/OasisTests
@@ -160,7 +145,7 @@ jobs:
             if: ${{ matrix.build_profiling }}
             uses: actions/upload-artifact@v3
             with:
-              name: build-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.c_compiler }}
+              name: build-linux-${{ matrix.build_type }}-${{ matrix.c_compiler }}
               path: |
                 ${{ steps.strings.outputs.build-dir }}
                 !${{ steps.strings.outputs.build-dir }}/_deps

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -1,0 +1,88 @@
+# ##############################################################################
+# OASIS: Open Algebra Software for Inferring Solutions
+#
+# cmake-windows.yml
+# ##############################################################################
+
+name: CMake on Windows
+
+on:
+    push:
+        branches: [ "master" ]
+    pull_request:
+        branches: [ "master" ]
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    build_and_test:
+        runs-on: windows-latest
+
+        strategy:
+            # Sets fail-fast to false to ensure that feedback is delivered for all platforms.
+            fail-fast: false
+
+            # Due to a bug in GCC (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111485), building with GCC is disabled.
+            matrix:
+                build_type: [ Release, Debug ]
+
+        steps:
+            # Checks out the repository.
+          - name: Checkout repository
+            uses: actions/checkout@v4
+
+          - name: Set reusable strings
+            id: strings
+            shell: bash
+            run: |
+              echo "build-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+
+            # Configures CMake in a subdirectory.
+          - name: Configure CMake
+            run: >
+                cmake
+                -B ${{ steps.strings.outputs.build-dir }}
+                -S ${{ github.workspace }}
+                -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+                -DOASIS_BUILD_IO=ON
+                -DOASIS_BUILD_PARANOID=ON
+
+            # Builds Oasis with the given configuration.
+          - name: Build Oasis
+            run: >
+                cmake
+                --build ${{ steps.strings.outputs.build-dir }}
+                --config ${{ matrix.build_type }}
+                --target Oasis
+
+            # Builds the tests for Oasis with the given configurations.
+          - name: Build OasisTests
+            run: >
+                cmake
+                --build ${{ steps.strings.outputs.build-dir }}
+                --config ${{ matrix.build_type }}
+                --target OasisTests
+
+          - name: Build OasisIOTests
+            run: >
+                cmake
+                --build ${{ steps.strings.outputs.build-dir }}
+                --config Debug
+                --target OasisIOTests
+
+            # Runs the tests registered to CTest by CMake.
+          - name: Test
+            working-directory: ${{ steps.strings.outputs.build-dir }}
+            run: ctest --build-config ${{ matrix.build_type }}
+
+            # Uploads the build, test, and code coverage artifacts.
+          - name: Upload artifacts
+            if: ${{ matrix.build_profiling }}
+            uses: actions/upload-artifact@v3
+            with:
+              name: build-windows-${{ matrix.build_type }}-${{ matrix.c_compiler }}
+              path: |
+                ${{ steps.strings.outputs.build-dir }}
+                !${{ steps.strings.outputs.build-dir }}/_deps

--- a/.gitignore
+++ b/.gitignore
@@ -100,7 +100,8 @@ latex
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*
@@ -127,3 +128,4 @@ Temporary Items
 
 # End of https://www.toptal.com/developers/gitignore/api/clion+all,macos,doxygen
 
+.cache/jb


### PR DESCRIPTION
Introduced a new GitHub Actions workflow `cmake-windows.yml` to handle building and testing on Windows. Removed Valgrind installation and memory checks from the multi-platform workflow. Updated `.gitignore` to exclude JetBrains cache files.