### PR TITLE
Fix ambiguity error with GCC

### DIFF
--- a/include/Oasis/Expression.hpp
+++ b/include/Oasis/Expression.hpp
@@ -1,6 +1,7 @@
 #ifndef OASIS_EXPRESSION_HPP
 #define OASIS_EXPRESSION_HPP
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 
@@ -142,11 +143,12 @@ public:
         return GetType() == T<Expression>::GetStaticType();
     }
 
-    template <template <typename, typename> typename T>
-    [[nodiscard]] bool Is() const
-    {
-        return GetType() == T<Expression, Expression>::GetStaticType();
-    }
+    // TODO: Investigate.
+    // template <template <typename, typename> typename T>
+    // [[nodiscard]] bool Is() const
+    // {
+    //     return GetType() == T<Expression, Expression>::GetStaticType();
+    // }
 
     /**
      * Simplifies this expression.

--- a/include/Oasis/Negate.hpp
+++ b/include/Oasis/Negate.hpp
@@ -10,7 +10,7 @@
 
 namespace Oasis {
 
-template <typename OperandT>
+template <typename OperandT = Expression>
 class Negate final : public UnaryExpression<Negate, OperandT> {
 public:
     Negate() = default;


### PR DESCRIPTION
In this pull request, the ambiguity error with GCC is addressed by commenting out the method `Is()` in `Expression.hpp`. Additionally, `<cstdint>` is included for potential type usage, and a default parameter is added to `Negate` to improve flexibility and simplify usage.