### PR TITLE
Update upload-artifact action to version 4

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -120,7 +120,7 @@ jobs:
             # Uploads the build, test, and code coverage artifacts.
           - name: Upload artifacts
             if: ${{ matrix.build_profiling }}
-            uses: actions/upload-artifact@v3
+            uses: actions/upload-artifact@v4
             with:
               name: build-linux-${{ matrix.build_type }}-${{ matrix.c_compiler }}
               path: |
@@ -129,7 +129,7 @@ jobs:
                 ${{ steps.strings.outputs.coverage-dir }}
 
           - name: Upload PR number
-            uses: actions/upload-artifact@v3
+            uses: actions/upload-artifact@v4
             with:
               name: pr-number
               path: ${{ steps.strings.outputs.pr-dir }}

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -127,9 +127,11 @@ jobs:
                 ${{ steps.strings.outputs.build-dir }}
                 !${{ steps.strings.outputs.build-dir }}/_deps
                 ${{ steps.strings.outputs.coverage-dir }}
+              overwrite: true
 
           - name: Upload PR number
             uses: actions/upload-artifact@v4
             with:
               name: pr-number
               path: ${{ steps.strings.outputs.pr-dir }}
+              overwrite: true

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -80,7 +80,7 @@ jobs:
             # Uploads the build, test, and code coverage artifacts.
           - name: Upload artifacts
             if: ${{ matrix.build_profiling }}
-            uses: actions/upload-artifact@v3
+            uses: actions/upload-artifact@v4
             with:
               name: build-windows-${{ matrix.build_type }}-${{ matrix.c_compiler }}
               path: |

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -86,3 +86,4 @@ jobs:
               path: |
                 ${{ steps.strings.outputs.build-dir }}
                 !${{ steps.strings.outputs.build-dir }}/_deps
+              overwrite: true


### PR DESCRIPTION
Upgraded actions/upload-artifact from version 3 to version 4 in GitHub workflows for both Linux and Windows. This ensures compatibility with the latest features and fixes provided by the updated action version.