### PR TITLE
Introduce `OASIS_CAPTURE_WITH_SERIALIZER`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,10 +45,10 @@ include(cmake/FetchTinyxml2.cmake)
 add_subdirectory(include)
 add_subdirectory(src)
 
-if(OASIS_BUILD_TESTS)
-    add_subdirectory(tests)
-endif()
-
 if(OASIS_BUILD_IO)
     add_subdirectory(io)
+endif()
+
+if(OASIS_BUILD_TESTS)
+    add_subdirectory(tests)
 endif()

--- a/io/include/Oasis/InFixSerializer.hpp
+++ b/io/include/Oasis/InFixSerializer.hpp
@@ -26,6 +26,10 @@ public:
     void Visit(const Negate<Expression>& negate) override;
     void Visit(const Derivative<Expression, Expression>& derivative) override;
     void Visit(const Integral<Expression, Expression>& integral) override;
+    void Visit(const Matrix& matrix) override;
+    void Visit(const EulerNumber&) override;
+    void Visit(const Pi&) override;
+    void Visit(const Magnitude<Expression>& magnitude) override;
 
     [[nodiscard]] std::string getResult() const;
 

--- a/io/src/InFixSerializer.cpp
+++ b/io/src/InFixSerializer.cpp
@@ -12,6 +12,7 @@
 #include "Oasis/Exponent.hpp"
 #include "Oasis/Integral.hpp"
 #include "Oasis/Log.hpp"
+#include "Oasis/Magnitude.hpp"
 #include "Oasis/Multiply.hpp"
 #include "Oasis/Negate.hpp"
 #include "Oasis/Real.hpp"
@@ -134,6 +135,27 @@ void InFixSerializer::Visit(const Integral<>& integral)
     const auto leastSigOpStr = getResult();
 
     result = fmt::format("in({},{})", mostSigOpStr, leastSigOpStr);
+}
+
+void InFixSerializer::Visit(const Matrix& matrix)
+{
+    result = "";
+}
+
+void InFixSerializer::Visit(const EulerNumber&)
+{
+    result = "e";
+}
+
+void InFixSerializer::Visit(const Pi&)
+{
+    result = "pi";
+}
+
+void InFixSerializer::Visit(const Magnitude<Expression>& magnitude)
+{
+    magnitude.GetOperand().Accept(*this);
+    result = fmt::format("|{}|", getResult());
 }
 
 std::string InFixSerializer::getResult() const

--- a/tests/AddTests.cpp
+++ b/tests/AddTests.cpp
@@ -1,6 +1,8 @@
 //
 // Created by Matthew McCall on 8/7/23.
 //
+#include "Common.hpp"
+
 #include "catch2/catch_test_macros.hpp"
 
 #include "Oasis/Add.hpp"
@@ -10,8 +12,7 @@
 #include "Oasis/Real.hpp"
 #include "Oasis/RecursiveCast.hpp"
 #include "Oasis/Variable.hpp"
-
-#include <functional>
+#include "Oasis/InFixSerializer.hpp"
 
 TEST_CASE("Addition", "[Add]")
 {
@@ -21,6 +22,9 @@ TEST_CASE("Addition", "[Add]")
             Oasis::Real { 2.0 } },
         Oasis::Real { 3.0 }
     };
+
+    Oasis::InFixSerializer serializer;
+    OASIS_CAPTURE_WITH_SERIALIZER(serializer, add);
 
     auto simplified = add.Simplify();
     REQUIRE(simplified->Is<Oasis::Real>());

--- a/tests/AddTests.cpp
+++ b/tests/AddTests.cpp
@@ -12,7 +12,6 @@
 #include "Oasis/Real.hpp"
 #include "Oasis/RecursiveCast.hpp"
 #include "Oasis/Variable.hpp"
-#include "Oasis/InFixSerializer.hpp"
 
 TEST_CASE("Addition", "[Add]")
 {
@@ -23,8 +22,7 @@ TEST_CASE("Addition", "[Add]")
         Oasis::Real { 3.0 }
     };
 
-    Oasis::InFixSerializer serializer;
-    OASIS_CAPTURE_WITH_SERIALIZER(serializer, add);
+    OASIS_CAPTURE_WITH_SERIALIZER(add);
 
     auto simplified = add.Simplify();
     REQUIRE(simplified->Is<Oasis::Real>());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(Oasis_TESTS
     # cmake-format: sortable
     AddTests.cpp
     BinaryExpressionTests.cpp
+    Common.hpp
     DifferentiateTests.cpp
     DivideTests.cpp
     ExponentTests.cpp
@@ -21,8 +22,7 @@ set(Oasis_TESTS
     NegateTests.cpp
     PolynomialTests.cpp
     SubtractTests.cpp
-    UnaryExpressionTests.cpp
-        Common.hpp)
+    UnaryExpressionTests.cpp)
 
 # Adds an executable target called "OasisTests" to be built from sources files.
 add_executable(OasisTests ${Oasis_TESTS})
@@ -36,12 +36,12 @@ endif()
 
 target_link_libraries(OasisTests PRIVATE Oasis::Oasis Catch2::Catch2WithMain)
 
-if (OASIS_BUILD_IO)
+if(OASIS_BUILD_IO)
     target_link_libraries(OasisTests PRIVATE Oasis::IO)
     target_compile_definitions(OasisTests PRIVATE OASIS_IO_ENABLED)
-endif ()
+endif()
 
-    # Automatically registers the tests with CTest.
+# Automatically registers the tests with CTest.
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 include(Catch)
 catch_discover_tests(OasisTests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,8 @@ set(Oasis_TESTS
     NegateTests.cpp
     PolynomialTests.cpp
     SubtractTests.cpp
-    UnaryExpressionTests.cpp)
+    UnaryExpressionTests.cpp
+        Common.hpp)
 
 # Adds an executable target called "OasisTests" to be built from sources files.
 add_executable(OasisTests ${Oasis_TESTS})
@@ -35,7 +36,12 @@ endif()
 
 target_link_libraries(OasisTests PRIVATE Oasis::Oasis Catch2::Catch2WithMain)
 
-# Automatically registers the tests with CTest.
+if (OASIS_BUILD_IO)
+    target_link_libraries(OasisTests PRIVATE Oasis::IO)
+    target_compile_definitions(OasisTests PRIVATE OASIS_IO_ENABLED)
+endif ()
+
+    # Automatically registers the tests with CTest.
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 include(Catch)
 catch_discover_tests(OasisTests)

--- a/tests/Common.hpp
+++ b/tests/Common.hpp
@@ -5,13 +5,16 @@
 #ifndef COMMON_HPP
 #define COMMON_HPP
 
+
 #ifdef OASIS_IO_ENABLED
-#define OASIS_CAPTURE_WITH_SERIALIZER(serializer, __expr) \
-__expr.Accept(serializer);                        \
-auto __expr_str = serializer.getResult();          \
+#include "Oasis/InFixSerializer.hpp"
+inline     Oasis::InFixSerializer __serializer;
+#define OASIS_CAPTURE_WITH_SERIALIZER(__expr) \
+__expr.Accept(__serializer);                        \
+auto __expr_str = __serializer.getResult();          \
 INFO(#__expr << " := " << __expr_str);
 #else
-#define OASIS_CAPTURE_WITH_SERIALIZER(serializer, __expr)
+#define OASIS_CAPTURE_WITH_SERIALIZER(__serializer, __expr)
 #endif
 
 #endif //COMMON_HPP

--- a/tests/Common.hpp
+++ b/tests/Common.hpp
@@ -14,7 +14,7 @@ __expr.Accept(__serializer);                        \
 auto __expr_str = __serializer.getResult();          \
 INFO(#__expr << " := " << __expr_str);
 #else
-#define OASIS_CAPTURE_WITH_SERIALIZER(__serializer, __expr)
+#define OASIS_CAPTURE_WITH_SERIALIZER(__expr)
 #endif
 
 #endif //COMMON_HPP

--- a/tests/Common.hpp
+++ b/tests/Common.hpp
@@ -1,0 +1,17 @@
+//
+// Created by Matthew McCall on 1/31/25.
+//
+
+#ifndef COMMON_HPP
+#define COMMON_HPP
+
+#ifdef OASIS_IO_ENABLED
+#define OASIS_CAPTURE_WITH_SERIALIZER(serializer, __expr) \
+__expr.Accept(serializer);                        \
+auto __expr_str = serializer.getResult();          \
+INFO(#__expr << " := " << __expr_str);
+#else
+#define OASIS_CAPTURE_WITH_SERIALIZER(serializer, __expr)
+#endif
+
+#endif //COMMON_HPP


### PR DESCRIPTION
This pull request includes the following changes:
- **Introduce OASIS_CAPTURE_WITH_SERIALIZER macro definition:** This macro provides an easy way to log the value of an expression in test cases.
- **Refactor serializer usage:** Introduced a global inline instance for streamlining usage of `OASIS_CAPTURE_WITH_SERIALIZER`. Simplified macro definition and removed redundant includes to enhance maintainability.
- **Reorganize test logic and enhance InFixSerializer:** Modularized test build configuration, introduced `Common.hpp` for shared test macros, and added support for new types (e.g., `Matrix`, `EulerNumber`, `Pi`, `Magnitude`) in `InFixSerializer`. Updated tests to align with enhanced serializer functionality.

### Checklist
- [x] Code changes are covered by tests.
- [x] Documentation is updated if applicable.  
- [x] Ensure all checks have passed. 