### PR TITLE
Multiplying fractions

### DIFF
--- a/src/Multiply.cpp
+++ b/src/Multiply.cpp
@@ -93,10 +93,7 @@ auto Multiply<Expression>::Simplify() const -> std::unique_ptr<Expression>
         auto m = Multiply<Expression> { multCase->GetMostSigOp(), multCase->GetLeastSigOp().GetMostSigOp() }.Simplify();
         return Divide<Expression> { *m, (multCase->GetLeastSigOp().GetLeastSigOp()) }.Simplify();
     }
-    if (auto multCase = RecursiveCast<Multiply<Divide<Expression>, Expression>>(simplifiedMultiply); multCase != nullptr) {
-        auto m = Multiply<Expression> { multCase->GetMostSigOp(), multCase->GetMostSigOp().GetMostSigOp() }.Simplify();
-        return Divide<Expression> { *m, (multCase->GetMostSigOp().GetLeastSigOp()) }.Simplify();
-    }
+
     if (auto multCase = RecursiveCast<Multiply<Divide<Expression>, Divide<Expression>>>(simplifiedMultiply); multCase != nullptr) {
         auto m = Multiply<Expression> { multCase->GetMostSigOp(), multCase->GetLeastSigOp().GetMostSigOp() }.Simplify();
         auto n = Multiply<Expression> { multCase->GetMostSigOp().GetLeastSigOp(), multCase->GetLeastSigOp().GetLeastSigOp() }.Simplify();

--- a/src/Multiply.cpp
+++ b/src/Multiply.cpp
@@ -89,6 +89,20 @@ auto Multiply<Expression>::Simplify() const -> std::unique_ptr<Expression>
     //                   Multiply{negated->GetMostSigOp(), negated->GetLeastSigOp().GetLeastSigOp()}}.Simplify();
     //    }
 
+    if (auto multCase = RecursiveCast<Multiply<Expression, Divide<Expression>>>(simplifiedMultiply); multCase != nullptr) {
+        auto m = Multiply<Expression> { multCase->GetMostSigOp(), multCase->GetLeastSigOp().GetMostSigOp() }.Simplify();
+        return Divide<Expression> { *m, (multCase->GetLeastSigOp().GetLeastSigOp()) }.Simplify();
+    }
+    if (auto multCase = RecursiveCast<Multiply<Divide<Expression>, Expression>>(simplifiedMultiply); multCase != nullptr) {
+        auto m = Multiply<Expression> { multCase->GetMostSigOp(), multCase->GetMostSigOp().GetMostSigOp() }.Simplify();
+        return Divide<Expression> { *m, (multCase->GetMostSigOp().GetLeastSigOp()) }.Simplify();
+    }
+    if (auto multCase = RecursiveCast<Multiply<Divide<Expression>, Divide<Expression>>>(simplifiedMultiply); multCase != nullptr) {
+        auto m = Multiply<Expression> { multCase->GetMostSigOp(), multCase->GetLeastSigOp().GetMostSigOp() }.Simplify();
+        auto n = Multiply<Expression> { multCase->GetMostSigOp().GetLeastSigOp(), multCase->GetLeastSigOp().GetLeastSigOp() }.Simplify();
+        return Divide<Expression> { *m, *n }.Simplify();
+    }
+
     if (auto exprCase = RecursiveCast<Multiply<Expression, Exponent<Expression, Expression>>>(simplifiedMultiply); exprCase != nullptr) {
         if (exprCase->GetMostSigOp().Equals(exprCase->GetLeastSigOp().GetMostSigOp())) {
             return std::make_unique<Exponent<Expression>>(exprCase->GetMostSigOp(),

--- a/tests/DifferentiateTests.cpp
+++ b/tests/DifferentiateTests.cpp
@@ -349,8 +349,10 @@ TEST_CASE("Expresion Base Exponential Derivative", "[Derivative][Exponent]")
 {
     Oasis::Exponent exp{ Oasis::Add { Oasis::Variable{"x"}, Oasis::Real{3.0} } , Oasis::Real{2.0}};
     Oasis::Derivative diffExp{exp, Oasis::Variable{"x"}};
-    Oasis::Multiply expected{ exp, Oasis::Divide { Oasis::Real{2.0} ,
-                                        Oasis::Add {Oasis::Variable{"x"} , Oasis::Real {3.0}} }  };
+    // Oasis::Multiply expected{ exp, Oasis::Divide { Oasis::Real{2.0} ,
+    //                                     Oasis::Add {Oasis::Variable{"x"} , Oasis::Real {3.0}} }  };
+
+    Oasis::Multiply expected{ Oasis::Add {Oasis::Variable{"x"} , Oasis::Real {3.0} }, Oasis::Real{ 2.0}    };
     auto simplified = diffExp.Simplify();
     REQUIRE(simplified->Equals(expected));
 }

--- a/tests/DifferentiateTests.cpp
+++ b/tests/DifferentiateTests.cpp
@@ -349,10 +349,9 @@ TEST_CASE("Expresion Base Exponential Derivative", "[Derivative][Exponent]")
 {
     Oasis::Exponent exp{ Oasis::Add { Oasis::Variable{"x"}, Oasis::Real{3.0} } , Oasis::Real{2.0}};
     Oasis::Derivative diffExp{exp, Oasis::Variable{"x"}};
-    // Oasis::Multiply expected{ exp, Oasis::Divide { Oasis::Real{2.0} ,
-    //                                     Oasis::Add {Oasis::Variable{"x"} , Oasis::Real {3.0}} }  };
 
     Oasis::Multiply expected{ Oasis::Add {Oasis::Variable{"x"} , Oasis::Real {3.0} }, Oasis::Real{ 2.0}    };
+
     auto simplified = diffExp.Simplify();
     REQUIRE(simplified->Equals(expected));
 }

--- a/tests/MultiplyTests.cpp
+++ b/tests/MultiplyTests.cpp
@@ -11,6 +11,8 @@
 #include "Oasis/Real.hpp"
 #include "Oasis/RecursiveCast.hpp"
 
+#include <Oasis/Divide.hpp>
+
 TEST_CASE("Multiplication", "[Multiply]")
 {
     Oasis::Multiply subtract {
@@ -123,6 +125,25 @@ TEST_CASE("Variadic Multiply Constructor", "[Multiply]")
     };
 
     const Oasis::Real expected { 432.0 };
+
+    const auto simplified = multiply.Simplify();
+    REQUIRE(expected.Equals(*simplified));
+}
+
+TEST_CASE("Multiplying Fractions", "[Multiply]")
+{
+    const Oasis::Multiply<Oasis::Divide<>,Oasis::Divide<>> multiply {
+            Oasis::Divide<> { Oasis::Multiply{ Oasis::Variable{ "a"},
+                        Oasis::Variable{"b"} },
+                Oasis::Multiply{ Oasis::Variable{ "c"},
+                        Oasis::Real{4.0} } },
+            Oasis::Divide<> { Oasis::Multiply{ Oasis::Variable{ "c"},
+                    Oasis::Real{12.0} },
+                Oasis::Multiply{ Oasis::Variable{ "b"},
+                        Oasis::Variable{"a"} } }
+    };
+
+    const Oasis::Real expected { 3.0 };
 
     const auto simplified = multiply.Simplify();
     REQUIRE(expected.Equals(*simplified));


### PR DESCRIPTION
Made it so that when multiplying a expression with a fraction it will combine into a single fraction
For example:
a*(1/x)
will become:
a/x
and similarly:
a/b * (c/d)
will become:
ac/(bd)

Also added new test case for this and changed existing test case to account for these changes.

Addresses issue #154 
