### PR TITLE
Fixes mistake in pull request #149

### DIFF
--- a/src/Exponent.cpp
+++ b/src/Exponent.cpp
@@ -158,23 +158,15 @@ auto Exponent<Expression>::Differentiate(const Expression& differentiationVariab
             return derivative.Simplify();
         }
 
-        if (auto samevarBase = RecursiveCast<Exponent<Variable, Expression>>(*simplifiedExponent); samevarBase != nullptr) {
-            const Variable& expBase = samevarBase->GetMostSigOp();
-            if (expBase.GetName() == variable->GetName()) {
-                Multiply derivative { Multiply { Derivative { samevarBase->GetLeastSigOp(), differentiationVariable }, *simplifiedExponent }, Add { Log { EulerNumber {}, samevarBase->GetMostSigOp() }, Real { 1 } } };
-                return derivative.Simplify();
-            }
-        }
-
         if (auto varBase = RecursiveCast<Exponent<Variable, Expression>>(*simplifiedExponent); varBase != nullptr) {
             Multiply derivative { Multiply { Derivative { varBase->GetLeastSigOp(), differentiationVariable }, *simplifiedExponent }, Log { EulerNumber {}, varBase->GetMostSigOp() } };
             return derivative.Simplify();
         }
 
-        if (auto generalBase = RecursiveCast<Exponent<Expression, Expression>>(*simplifiedExponent); generalBase != nullptr) {
+        if (auto generalCase = RecursiveCast<Exponent<Expression, Expression>>(*simplifiedExponent); generalCase != nullptr) {
             Multiply derivative { Multiply { *simplifiedExponent,
-                Add { Divide { Multiply { generalBase->GetLeastSigOp(), Derivative { generalBase->GetMostSigOp(), differentiationVariable } }, generalBase->GetMostSigOp() },
-                    Multiply { Derivative { generalBase->GetLeastSigOp(), differentiationVariable }, Log { EulerNumber {}, generalBase->GetMostSigOp() } } } } };
+                Add { Divide { Multiply { generalCase->GetLeastSigOp(), Derivative { generalCase->GetMostSigOp(), differentiationVariable } }, generalCase->GetMostSigOp() },
+                    Multiply { Derivative { generalCase->GetLeastSigOp(), differentiationVariable }, Log { EulerNumber {}, generalCase->GetMostSigOp() } } } } };
             return derivative.Simplify();
         }
     }

--- a/tests/DifferentiateTests.cpp
+++ b/tests/DifferentiateTests.cpp
@@ -319,16 +319,6 @@ TEST_CASE("Any Base Exponential Derivative", "[Derivative][Exponent]")
     REQUIRE(simplified->Equals(expected));
 }
 
-TEST_CASE("Variable Base Exponential Derivative", "[Derivative][Exponent]")
-{
-    Oasis::Exponent exp{Oasis::Variable{"x"}, Oasis::Multiply{Oasis::Real{2.0},Oasis::Variable{"x"}}};
-    Oasis::Derivative diffExp{exp, Oasis::Variable{"x"}};
-    Oasis::Multiply expected{Oasis::Multiply{Oasis::Real{2.0}, exp},
-                                            Oasis::Add{ Oasis::Log{Oasis::EulerNumber{}, Oasis::Variable{"x"}},Oasis::Real{1.0}}};
-    auto simplified = diffExp.Simplify();
-    REQUIRE(simplified->Equals(expected));
-}
-
 TEST_CASE("General Exponential Derivative", "[Derivative][Exponent]")
 {
     Oasis::Exponent exp{ Oasis::Add { Oasis::Variable{"x"}, Oasis::Real{3.0} },


### PR DESCRIPTION
the section removed incorrectly assumes the exponent has no added constants
making it wrong for derivatives of functions like: x^(3x+2)

also removed associated test case, and changed name from generalBase to generalCase

Refixes issue #146 
fixes issue with pull request #149 