### PR TITLE
Refactor `MatchCast` for type safety, C++23, and Boost enhancements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,14 @@ add_subdirectory(include)
 add_subdirectory(src)
 
 if(OASIS_BUILD_IO)
+    FetchContent_Declare(GSL
+            GIT_REPOSITORY "https://github.com/microsoft/GSL"
+            GIT_TAG "v4.1.0"
+            GIT_SHALLOW ON
+    )
+
+    FetchContent_MakeAvailable(GSL)
+
     add_subdirectory(io)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,11 +41,11 @@ add_subdirectory(include)
 add_subdirectory(src)
 
 if(OASIS_BUILD_IO)
-    FetchContent_Declare(GSL
-            GIT_REPOSITORY "https://github.com/microsoft/GSL"
-            GIT_TAG "v4.1.0"
-            GIT_SHALLOW ON
-    )
+    FetchContent_Declare(
+        GSL
+        GIT_REPOSITORY "https://github.com/microsoft/GSL"
+        GIT_TAG "v4.1.0"
+        GIT_SHALLOW ON)
 
     FetchContent_MakeAvailable(GSL)
 

--- a/cmake/FetchBoost.cmake
+++ b/cmake/FetchBoost.cmake
@@ -6,5 +6,5 @@ FetchContent_Declare(
         EXCLUDE_FROM_ALL
 )
 
-set(BOOST_INCLUDE_LIBRARIES any mpl)
+set(BOOST_INCLUDE_LIBRARIES any callable_traits mpl)
 FetchContent_MakeAvailable(Boost)

--- a/cmake/FetchBoost.cmake
+++ b/cmake/FetchBoost.cmake
@@ -6,5 +6,5 @@ FetchContent_Declare(
         EXCLUDE_FROM_ALL
 )
 
-set(BOOST_INCLUDE_LIBRARIES mpl)
+set(BOOST_INCLUDE_LIBRARIES any mpl)
 FetchContent_MakeAvailable(Boost)

--- a/cmake/FetchEigen.cmake
+++ b/cmake/FetchEigen.cmake
@@ -10,7 +10,7 @@
 FetchContent_Declare(
     eigen
     GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
-    GIT_TAG 3.4.0)
+    GIT_TAG nightly)
 
 # Disables some of eigen's build options.
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -30,7 +30,7 @@ set(Oasis_HEADERS
 add_library(OasisHeaders INTERFACE)
 add_library(Oasis::Headers ALIAS OasisHeaders)
 
-target_compile_features(OasisHeaders INTERFACE cxx_std_20)
+target_compile_features(OasisHeaders INTERFACE cxx_std_23)
 target_include_directories(
     OasisHeaders INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                            $<INSTALL_INTERFACE:include>)

--- a/include/Oasis/BinaryExpression.hpp
+++ b/include/Oasis/BinaryExpression.hpp
@@ -378,7 +378,7 @@ public:
 
     auto operator=(const BinaryExpression& other) -> BinaryExpression& = default;
 
-    std::any AcceptInternal(Visitor& visitor) const override
+    auto AcceptInternal(Visitor& visitor) const -> any override
     {
         const auto generalized = Generalize();
         const auto& derivedGeneralized = dynamic_cast<const DerivedGeneralized&>(*generalized);

--- a/include/Oasis/Concepts.hpp
+++ b/include/Oasis/Concepts.hpp
@@ -65,6 +65,12 @@ concept IVisitor = requires {
     requires std::is_base_of_v<Visitor, T>; // Ensures T derives from BaseClass
 };
 
+template <typename T>
+concept ExpectedWithStringView = requires {
+    typename T::unexpected_type;
+    std::same_as<typename T::unexpected_type, std::unexpected<std::string_view>>;
+};
+
 }
 
 #endif // OASIS_CONCEPTS_HPP

--- a/include/Oasis/Concepts.hpp
+++ b/include/Oasis/Concepts.hpp
@@ -68,7 +68,7 @@ concept IVisitor = requires {
 template <typename T>
 concept ExpectedWithStringView = requires {
     typename T::unexpected_type;
-    std::same_as<typename T::unexpected_type, std::unexpected<std::string_view>>;
+    requires std::same_as<typename T::unexpected_type, std::unexpected<std::string_view>>;
 };
 
 }

--- a/include/Oasis/Expression.hpp
+++ b/include/Oasis/Expression.hpp
@@ -2,8 +2,8 @@
 #define OASIS_EXPRESSION_HPP
 
 #include <cstdint>
+#include <expected>
 #include <memory>
-#include <optional>
 #include <vector>
 
 #include <boost/any/unique_any.hpp>
@@ -178,7 +178,7 @@ public:
     [[nodiscard]] virtual auto Substitute(const Expression& var, const Expression& val) -> std::unique_ptr<Expression> = 0;
 
     template <IVisitor T>
-    std::optional<typename T::RetT> Accept(T& visitor) const;
+    auto Accept(T& visitor) const -> std::expected<typename T::RetT, std::string>;
 
     virtual ~Expression() = default;
 
@@ -192,12 +192,12 @@ protected:
 };
 
 template <IVisitor T>
-std::optional<typename T::RetT> Expression::Accept(T& visitor) const
+auto Expression::Accept(T& visitor) const -> std::expected<typename T::RetT, std::string>
 {
     try {
         return boost::any_cast<typename T::RetT>(this->AcceptInternal(visitor));
-    } catch (boost::bad_any_cast&) {
-        return std::nullopt;
+    } catch (boost::bad_any_cast& e) {
+        return std::unexpected { e.what() };
     }
 }
 

--- a/include/Oasis/Expression.hpp
+++ b/include/Oasis/Expression.hpp
@@ -180,7 +180,8 @@ public:
     template <IVisitor T>
     auto Accept(T& visitor) const -> std::expected<typename T::RetT, std::string_view>;
 
-    template <IVisitor T> requires ExpectedWithStringView<typename T::RetT>
+    template <IVisitor T>
+        requires ExpectedWithStringView<typename T::RetT>
     auto Accept(T& visitor) const -> typename T::RetT;
 
     virtual ~Expression() = default;
@@ -204,7 +205,8 @@ auto Expression::Accept(T& visitor) const -> std::expected<typename T::RetT, std
     }
 }
 
-template <IVisitor T> requires ExpectedWithStringView<typename T::RetT>
+template <IVisitor T>
+    requires ExpectedWithStringView<typename T::RetT>
 auto Expression::Accept(T& visitor) const -> typename T::RetT
 {
     try {

--- a/include/Oasis/Expression.hpp
+++ b/include/Oasis/Expression.hpp
@@ -1,15 +1,18 @@
 #ifndef OASIS_EXPRESSION_HPP
 #define OASIS_EXPRESSION_HPP
 
-#include <any>
 #include <cstdint>
 #include <memory>
 #include <optional>
 #include <vector>
 
+#include <boost/any/unique_any.hpp>
+
 #include "Concepts.hpp"
 
 namespace Oasis {
+
+using any = boost::anys::unique_any;
 
 class Visitor;
 
@@ -185,15 +188,15 @@ protected:
      *
      * @param visitor The serializer class object to write the Expression data.
      */
-    virtual std::any AcceptInternal(Visitor& visitor) const = 0;
+    virtual any AcceptInternal(Visitor& visitor) const = 0;
 };
 
 template <IVisitor T>
 std::optional<typename T::RetT> Expression::Accept(T& visitor) const
 {
     try {
-        return std::any_cast<typename T::RetT>(this->AcceptInternal(visitor));
-    } catch (std::bad_any_cast&) {
+        return boost::any_cast<typename T::RetT>(this->AcceptInternal(visitor));
+    } catch (boost::bad_any_cast&) {
         return std::nullopt;
     }
 }

--- a/include/Oasis/LeafExpression.hpp
+++ b/include/Oasis/LeafExpression.hpp
@@ -44,7 +44,7 @@ public:
         return this->Copy();
     }
 
-    std::any AcceptInternal(Visitor& visitor) const override
+    auto AcceptInternal(Visitor& visitor) const -> any override
     {
         const auto generalized = Generalize();
         const auto& derivedGeneralized = dynamic_cast<const DerivedT&>(*generalized);

--- a/include/Oasis/MatchCast.hpp
+++ b/include/Oasis/MatchCast.hpp
@@ -22,37 +22,53 @@
 #include <boost/mpl/push_back.hpp>
 #include <boost/mpl/vector.hpp>
 
+#include <concepts>
 #include <functional>
 #include <tuple>
 
-namespace Oasis {
-
-template <typename Lambda>
-using lambda_argument_type = std::remove_cvref_t<std::tuple_element_t<0, boost::callable_traits::args_t<Lambda>>>;
-
-template <typename ArgumentT, typename Cases>
-class MatchCastImpl {
-public:
+namespace Oasis
+{
     template <typename Lambda>
-    consteval auto Case(Lambda) const -> MatchCastImpl<ArgumentT, typename boost::mpl::push_back<Cases, Lambda>::type> { return {}; }
+    using lambda_argument_type = std::remove_cvref_t<std::tuple_element_t<0, boost::callable_traits::args_t<Lambda>>>;
 
-    auto Execute(const ArgumentT& arg, std::unique_ptr<ArgumentT>&& fallback) const -> std::unique_ptr<ArgumentT>
+    template <typename CheckF, typename TransformerF>
+    concept TransformerAcceptsCheckArg = requires(CheckF f1, TransformerF f2, const lambda_argument_type<CheckF>& t)
     {
-        std::unique_ptr<ArgumentT> result = nullptr;
-        boost::mpl::for_each<Cases>([&]<typename CaseTrueCallbackT>(CaseTrueCallbackT caseTrueCallback) {
-            using CaseType = lambda_argument_type<CaseTrueCallbackT>;
-            if (result)
-                return;
-            if (std::unique_ptr<CaseType> castResult = RecursiveCast<CaseType>(arg))
-                result = caseTrueCallback(*castResult);
-        });
-        return result ? std::move(result) : std::move(fallback);
-    }
-};
+        { f1(t) } -> std::convertible_to<bool>;
+        { f2(t) } -> std::same_as<std::unique_ptr<Expression>>;
+    };
 
-template <typename ArgumentT>
-using MatchCast = MatchCastImpl<ArgumentT, boost::mpl::vector<>>;
+    template <typename ArgumentT, typename Cases>
+    class MatchCastImpl
+    {
+    public:
+        template <typename Check, typename Transformer> requires TransformerAcceptsCheckArg<Check, Transformer>
+        consteval auto Case(
+            Check,
+            Transformer) const -> MatchCastImpl<ArgumentT, typename boost::mpl::push_back<
+                                                    Cases, std::pair<Check, Transformer>>::type> { return {}; }
 
+        auto Execute(const ArgumentT& arg, std::unique_ptr<ArgumentT>&& fallback) const -> std::unique_ptr<ArgumentT>
+        {
+            std::unique_ptr<ArgumentT> result = nullptr;
+            boost::mpl::for_each<Cases>(
+                [&]<typename Check, typename Transformer>(std::pair<Check, Transformer> checkAndTransformer)
+                {
+                    using CaseType = lambda_argument_type<Check>;
+                    if (result)
+                        return;
+
+                    auto [check, transformer] = checkAndTransformer;
+                    if (std::unique_ptr<CaseType> castResult = RecursiveCast<CaseType>(arg); castResult && check(
+                        *castResult))
+                        result = transformer(*castResult);
+                });
+            return result ? std::move(result) : std::move(fallback);
+        }
+    };
+
+    template <typename ArgumentT>
+    using MatchCast = MatchCastImpl<ArgumentT, boost::mpl::vector<>>;
 }
 
 #endif // OASIS_MATCHCAST_HPP

--- a/include/Oasis/MatchCast.hpp
+++ b/include/Oasis/MatchCast.hpp
@@ -40,7 +40,7 @@ template <typename ArgumentT, typename Cases>
 class MatchCastImpl {
 public:
     template <typename Lambda>
-    auto Case(Lambda) const -> MatchCastImpl<ArgumentT, typename boost::mpl::push_back<Cases, Lambda>::type> { return {}; }
+    consteval auto Case(Lambda) const -> MatchCastImpl<ArgumentT, typename boost::mpl::push_back<Cases, Lambda>::type> { return {}; }
 
     auto Execute(const ArgumentT& arg, std::unique_ptr<ArgumentT>&& fallback) const -> std::unique_ptr<ArgumentT>
     {

--- a/include/Oasis/MatchCast.hpp
+++ b/include/Oasis/MatchCast.hpp
@@ -17,24 +17,18 @@
 #ifndef OASIS_MATCHCAST_HPP
 #define OASIS_MATCHCAST_HPP
 
+#include <boost/callable_traits/args.hpp>
 #include <boost/mpl/for_each.hpp>
 #include <boost/mpl/push_back.hpp>
 #include <boost/mpl/vector.hpp>
 
 #include <functional>
+#include <tuple>
 
 namespace Oasis {
 
-template <typename T>
-struct lambda_traits;
-
-template <typename Ret, typename ClassType, typename Arg>
-struct lambda_traits<Ret (ClassType::*)(Arg) const> {
-    using argument_type = std::remove_cvref_t<Arg>;
-};
-
 template <typename Lambda>
-using lambda_argument_type = typename lambda_traits<decltype(&Lambda::operator())>::argument_type;
+using lambda_argument_type = std::remove_cvref_t<std::tuple_element_t<0, boost::callable_traits::args_t<Lambda>>>;
 
 template <typename ArgumentT, typename Cases>
 class MatchCastImpl {

--- a/include/Oasis/UnaryExpression.hpp
+++ b/include/Oasis/UnaryExpression.hpp
@@ -91,7 +91,7 @@ public:
         return ret;
     }
 
-    std::any AcceptInternal(Visitor& visitor) const override
+    auto AcceptInternal(Visitor& visitor) const -> any override
     {
         const auto generalized = Generalize();
         const auto& derivedGeneralized = dynamic_cast<const DerivedGeneralized&>(*generalized);

--- a/include/Oasis/Visit.hpp
+++ b/include/Oasis/Visit.hpp
@@ -75,42 +75,42 @@ class TypedVisitor : public Visitor {
 public:
     using RetT = T;
 
-    auto Visit(const Real& real)-> any final { return TypedVisit(real); }
-    auto Visit(const Imaginary& imaginary)-> any final { return TypedVisit(imaginary); }
-    auto Visit(const Matrix& matrix)-> any final { return TypedVisit(matrix); }
-    auto Visit(const Variable& variable)-> any final { return TypedVisit(variable); }
-    auto Visit(const Undefined& undefined)-> any final { return TypedVisit(undefined); }
-    auto Visit(const EulerNumber& e)-> any final { return TypedVisit(e); }
-    auto Visit(const Pi& pi)-> any final { return TypedVisit(pi); }
-    auto Visit(const Add<Expression, Expression>& add)-> any final { return TypedVisit(add); }
-    auto Visit(const Subtract<Expression, Expression>& subtract)-> any final { return TypedVisit(subtract); }
-    auto Visit(const Multiply<Expression, Expression>& multiply)-> any final { return TypedVisit(multiply); }
-    auto Visit(const Divide<Expression, Expression>& divide)-> any final { return TypedVisit(divide); }
-    auto Visit(const Exponent<Expression, Expression>& exponent)-> any final { return TypedVisit(exponent); }
-    auto Visit(const Log<Expression, Expression>& log)-> any final { return TypedVisit(log); }
-    auto Visit(const Negate<Expression>& negate)-> any final { return TypedVisit(negate); }
-    auto Visit(const Magnitude<Expression>& magnitude)-> any final { return TypedVisit(magnitude); }
-    auto Visit(const Derivative<Expression, Expression>& derivative)-> any final { return TypedVisit(derivative); }
-    auto Visit(const Integral<Expression, Expression>& integral)-> any final { return TypedVisit(integral); }
+    auto Visit(const Real& real) -> any final { return TypedVisit(real); }
+    auto Visit(const Imaginary& imaginary) -> any final { return TypedVisit(imaginary); }
+    auto Visit(const Matrix& matrix) -> any final { return TypedVisit(matrix); }
+    auto Visit(const Variable& variable) -> any final { return TypedVisit(variable); }
+    auto Visit(const Undefined& undefined) -> any final { return TypedVisit(undefined); }
+    auto Visit(const EulerNumber& e) -> any final { return TypedVisit(e); }
+    auto Visit(const Pi& pi) -> any final { return TypedVisit(pi); }
+    auto Visit(const Add<Expression, Expression>& add) -> any final { return TypedVisit(add); }
+    auto Visit(const Subtract<Expression, Expression>& subtract) -> any final { return TypedVisit(subtract); }
+    auto Visit(const Multiply<Expression, Expression>& multiply) -> any final { return TypedVisit(multiply); }
+    auto Visit(const Divide<Expression, Expression>& divide) -> any final { return TypedVisit(divide); }
+    auto Visit(const Exponent<Expression, Expression>& exponent) -> any final { return TypedVisit(exponent); }
+    auto Visit(const Log<Expression, Expression>& log) -> any final { return TypedVisit(log); }
+    auto Visit(const Negate<Expression>& negate) -> any final { return TypedVisit(negate); }
+    auto Visit(const Magnitude<Expression>& magnitude) -> any final { return TypedVisit(magnitude); }
+    auto Visit(const Derivative<Expression, Expression>& derivative) -> any final { return TypedVisit(derivative); }
+    auto Visit(const Integral<Expression, Expression>& integral) -> any final { return TypedVisit(integral); }
 
 protected:
-    virtual auto TypedVisit(const Real& real)-> RetT = 0;
-    virtual auto TypedVisit(const Imaginary& imaginary)-> RetT = 0;
-    virtual auto TypedVisit(const Matrix& matrix)-> RetT = 0;
-    virtual auto TypedVisit(const Variable& variable)-> RetT = 0;
-    virtual auto TypedVisit(const Undefined& undefined)-> RetT = 0;
-    virtual auto TypedVisit(const EulerNumber&)-> RetT = 0;
-    virtual auto TypedVisit(const Pi&)-> RetT = 0;
-    virtual auto TypedVisit(const Add<Expression, Expression>& add)-> RetT = 0;
-    virtual auto TypedVisit(const Subtract<Expression, Expression>& subtract)-> RetT = 0;
-    virtual auto TypedVisit(const Multiply<Expression, Expression>& multiply)-> RetT = 0;
-    virtual auto TypedVisit(const Divide<Expression, Expression>& divide)-> RetT = 0;
-    virtual auto TypedVisit(const Exponent<Expression, Expression>& exponent)-> RetT = 0;
-    virtual auto TypedVisit(const Log<Expression, Expression>& log)-> RetT = 0;
-    virtual auto TypedVisit(const Negate<Expression>& negate)-> RetT = 0;
-    virtual auto TypedVisit(const Magnitude<Expression>& magnitude)-> RetT = 0;
-    virtual auto TypedVisit(const Derivative<Expression, Expression>& derivative)-> RetT = 0;
-    virtual auto TypedVisit(const Integral<Expression, Expression>& integral)-> RetT = 0;
+    virtual auto TypedVisit(const Real& real) -> RetT = 0;
+    virtual auto TypedVisit(const Imaginary& imaginary) -> RetT = 0;
+    virtual auto TypedVisit(const Matrix& matrix) -> RetT = 0;
+    virtual auto TypedVisit(const Variable& variable) -> RetT = 0;
+    virtual auto TypedVisit(const Undefined& undefined) -> RetT = 0;
+    virtual auto TypedVisit(const EulerNumber&) -> RetT = 0;
+    virtual auto TypedVisit(const Pi&) -> RetT = 0;
+    virtual auto TypedVisit(const Add<Expression, Expression>& add) -> RetT = 0;
+    virtual auto TypedVisit(const Subtract<Expression, Expression>& subtract) -> RetT = 0;
+    virtual auto TypedVisit(const Multiply<Expression, Expression>& multiply) -> RetT = 0;
+    virtual auto TypedVisit(const Divide<Expression, Expression>& divide) -> RetT = 0;
+    virtual auto TypedVisit(const Exponent<Expression, Expression>& exponent) -> RetT = 0;
+    virtual auto TypedVisit(const Log<Expression, Expression>& log) -> RetT = 0;
+    virtual auto TypedVisit(const Negate<Expression>& negate) -> RetT = 0;
+    virtual auto TypedVisit(const Magnitude<Expression>& magnitude) -> RetT = 0;
+    virtual auto TypedVisit(const Derivative<Expression, Expression>& derivative) -> RetT = 0;
+    virtual auto TypedVisit(const Integral<Expression, Expression>& integral) -> RetT = 0;
 };
 
 }

--- a/include/Oasis/Visit.hpp
+++ b/include/Oasis/Visit.hpp
@@ -5,8 +5,6 @@
 #ifndef OASIS_SERIALIZATION_HPP
 #define OASIS_SERIALIZATION_HPP
 
-#include <any>
-
 #include "Expression.hpp"
 
 namespace Oasis {
@@ -51,23 +49,23 @@ class Integral;
 
 class Visitor {
 public:
-    virtual std::any Visit(const Real& real) = 0;
-    virtual std::any Visit(const Imaginary& imaginary) = 0;
-    virtual std::any Visit(const Matrix& matrix) = 0;
-    virtual std::any Visit(const Variable& variable) = 0;
-    virtual std::any Visit(const Undefined& undefined) = 0;
-    virtual std::any Visit(const EulerNumber&) = 0;
-    virtual std::any Visit(const Pi&) = 0;
-    virtual std::any Visit(const Add<Expression, Expression>& add) = 0;
-    virtual std::any Visit(const Subtract<Expression, Expression>& subtract) = 0;
-    virtual std::any Visit(const Multiply<Expression, Expression>& multiply) = 0;
-    virtual std::any Visit(const Divide<Expression, Expression>& divide) = 0;
-    virtual std::any Visit(const Exponent<Expression, Expression>& exponent) = 0;
-    virtual std::any Visit(const Log<Expression, Expression>& log) = 0;
-    virtual std::any Visit(const Negate<Expression>& negate) = 0;
-    virtual std::any Visit(const Magnitude<Expression>& magnitude) = 0;
-    virtual std::any Visit(const Derivative<Expression, Expression>& derivative) = 0;
-    virtual std::any Visit(const Integral<Expression, Expression>& integral) = 0;
+    virtual any Visit(const Real& real) = 0;
+    virtual any Visit(const Imaginary& imaginary) = 0;
+    virtual any Visit(const Matrix& matrix) = 0;
+    virtual any Visit(const Variable& variable) = 0;
+    virtual any Visit(const Undefined& undefined) = 0;
+    virtual any Visit(const EulerNumber&) = 0;
+    virtual any Visit(const Pi&) = 0;
+    virtual any Visit(const Add<Expression, Expression>& add) = 0;
+    virtual any Visit(const Subtract<Expression, Expression>& subtract) = 0;
+    virtual any Visit(const Multiply<Expression, Expression>& multiply) = 0;
+    virtual any Visit(const Divide<Expression, Expression>& divide) = 0;
+    virtual any Visit(const Exponent<Expression, Expression>& exponent) = 0;
+    virtual any Visit(const Log<Expression, Expression>& log) = 0;
+    virtual any Visit(const Negate<Expression>& negate) = 0;
+    virtual any Visit(const Magnitude<Expression>& magnitude) = 0;
+    virtual any Visit(const Derivative<Expression, Expression>& derivative) = 0;
+    virtual any Visit(const Integral<Expression, Expression>& integral) = 0;
 
     virtual ~Visitor() = default;
 };

--- a/include/Oasis/Visit.hpp
+++ b/include/Oasis/Visit.hpp
@@ -70,6 +70,49 @@ public:
     virtual ~Visitor() = default;
 };
 
+template <typename T>
+class TypedVisitor : public Visitor {
+public:
+    using RetT = T;
+
+    auto Visit(const Real& real)-> any final { return TypedVisit(real); }
+    auto Visit(const Imaginary& imaginary)-> any final { return TypedVisit(imaginary); }
+    auto Visit(const Matrix& matrix)-> any final { return TypedVisit(matrix); }
+    auto Visit(const Variable& variable)-> any final { return TypedVisit(variable); }
+    auto Visit(const Undefined& undefined)-> any final { return TypedVisit(undefined); }
+    auto Visit(const EulerNumber& e)-> any final { return TypedVisit(e); }
+    auto Visit(const Pi& pi)-> any final { return TypedVisit(pi); }
+    auto Visit(const Add<Expression, Expression>& add)-> any final { return TypedVisit(add); }
+    auto Visit(const Subtract<Expression, Expression>& subtract)-> any final { return TypedVisit(subtract); }
+    auto Visit(const Multiply<Expression, Expression>& multiply)-> any final { return TypedVisit(multiply); }
+    auto Visit(const Divide<Expression, Expression>& divide)-> any final { return TypedVisit(divide); }
+    auto Visit(const Exponent<Expression, Expression>& exponent)-> any final { return TypedVisit(exponent); }
+    auto Visit(const Log<Expression, Expression>& log)-> any final { return TypedVisit(log); }
+    auto Visit(const Negate<Expression>& negate)-> any final { return TypedVisit(negate); }
+    auto Visit(const Magnitude<Expression>& magnitude)-> any final { return TypedVisit(magnitude); }
+    auto Visit(const Derivative<Expression, Expression>& derivative)-> any final { return TypedVisit(derivative); }
+    auto Visit(const Integral<Expression, Expression>& integral)-> any final { return TypedVisit(integral); }
+
+protected:
+    virtual auto TypedVisit(const Real& real)-> RetT = 0;
+    virtual auto TypedVisit(const Imaginary& imaginary)-> RetT = 0;
+    virtual auto TypedVisit(const Matrix& matrix)-> RetT = 0;
+    virtual auto TypedVisit(const Variable& variable)-> RetT = 0;
+    virtual auto TypedVisit(const Undefined& undefined)-> RetT = 0;
+    virtual auto TypedVisit(const EulerNumber&)-> RetT = 0;
+    virtual auto TypedVisit(const Pi&)-> RetT = 0;
+    virtual auto TypedVisit(const Add<Expression, Expression>& add)-> RetT = 0;
+    virtual auto TypedVisit(const Subtract<Expression, Expression>& subtract)-> RetT = 0;
+    virtual auto TypedVisit(const Multiply<Expression, Expression>& multiply)-> RetT = 0;
+    virtual auto TypedVisit(const Divide<Expression, Expression>& divide)-> RetT = 0;
+    virtual auto TypedVisit(const Exponent<Expression, Expression>& exponent)-> RetT = 0;
+    virtual auto TypedVisit(const Log<Expression, Expression>& log)-> RetT = 0;
+    virtual auto TypedVisit(const Negate<Expression>& negate)-> RetT = 0;
+    virtual auto TypedVisit(const Magnitude<Expression>& magnitude)-> RetT = 0;
+    virtual auto TypedVisit(const Derivative<Expression, Expression>& derivative)-> RetT = 0;
+    virtual auto TypedVisit(const Integral<Expression, Expression>& integral)-> RetT = 0;
+};
+
 }
 
 #endif // OASIS_SERIALIZATION_HPP

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(OasisIO ${OASIS_IO_SOURCES} ${OASIS_IO_HEADERS})
 add_library(Oasis::IO ALIAS OasisIO)
 
 target_include_directories(OasisIO PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(OasisIO PUBLIC Oasis::Oasis tinyxml2::tinyxml2)
+target_link_libraries(OasisIO PUBLIC Oasis::Oasis Microsoft.GSL::GSL tinyxml2::tinyxml2)
 
 if(OASIS_BUILD_PARANOID)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -12,7 +12,8 @@ add_library(OasisIO ${OASIS_IO_SOURCES} ${OASIS_IO_HEADERS})
 add_library(Oasis::IO ALIAS OasisIO)
 
 target_include_directories(OasisIO PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(OasisIO PUBLIC Oasis::Oasis Microsoft.GSL::GSL tinyxml2::tinyxml2)
+target_link_libraries(OasisIO PUBLIC Oasis::Oasis Microsoft.GSL::GSL
+                                     tinyxml2::tinyxml2)
 
 if(OASIS_BUILD_PARANOID)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")

--- a/io/include/Oasis/FromString.hpp
+++ b/io/include/Oasis/FromString.hpp
@@ -5,8 +5,8 @@
 #ifndef FROMSTRING_HPP
 #define FROMSTRING_HPP
 
+#include <expected>
 #include <memory>
-#include <variant>
 
 #include "Oasis/Expression.hpp"
 
@@ -17,22 +17,9 @@ enum class ParseImaginaryOption {
     UseJ
 };
 
-class ParseResult {
-public:
-    explicit ParseResult(std::unique_ptr<Expression> expr);
-    explicit ParseResult(std::string err);
-
-    [[nodiscard]] bool Ok() const;
-    [[nodiscard]] const Expression& GetResult() const;
-    [[nodiscard]] std::string GetErrorMessage() const;
-
-private:
-    std::variant<std::unique_ptr<Expression>, std::string> result;
-};
-
 auto PreProcessInFix(const std::string& str) -> std::string;
 
-auto FromInFix(const std::string& str, ParseImaginaryOption option = ParseImaginaryOption::UseI) -> ParseResult;
+auto FromInFix(const std::string& str, ParseImaginaryOption option = ParseImaginaryOption::UseI) -> std::expected<std::unique_ptr<Expression>, std::string>;
 
 }
 

--- a/io/include/Oasis/InFixSerializer.hpp
+++ b/io/include/Oasis/InFixSerializer.hpp
@@ -16,23 +16,23 @@ class InFixSerializer final : public Visitor {
 public:
     using RetT = std::string;
 
-    std::any Visit(const Real& real) override;
-    std::any Visit(const Imaginary& imaginary) override;
-    std::any Visit(const Variable& variable) override;
-    std::any Visit(const Undefined& undefined) override;
-    std::any Visit(const Add<Expression, Expression>& add) override;
-    std::any Visit(const Subtract<Expression, Expression>& subtract) override;
-    std::any Visit(const Multiply<Expression, Expression>& multiply) override;
-    std::any Visit(const Divide<Expression, Expression>& divide) override;
-    std::any Visit(const Exponent<Expression, Expression>& exponent) override;
-    std::any Visit(const Log<Expression, Expression>& log) override;
-    std::any Visit(const Negate<Expression>& negate) override;
-    std::any Visit(const Derivative<Expression, Expression>& derivative) override;
-    std::any Visit(const Integral<Expression, Expression>& integral) override;
-    std::any Visit(const Matrix& matrix) override;
-    std::any Visit(const EulerNumber&) override;
-    std::any Visit(const Pi&) override;
-    std::any Visit(const Magnitude<Expression>& magnitude) override;
+    any Visit(const Real& real) override;
+    any Visit(const Imaginary& imaginary) override;
+    any Visit(const Variable& variable) override;
+    any Visit(const Undefined& undefined) override;
+    any Visit(const Add<Expression, Expression>& add) override;
+    any Visit(const Subtract<Expression, Expression>& subtract) override;
+    any Visit(const Multiply<Expression, Expression>& multiply) override;
+    any Visit(const Divide<Expression, Expression>& divide) override;
+    any Visit(const Exponent<Expression, Expression>& exponent) override;
+    any Visit(const Log<Expression, Expression>& log) override;
+    any Visit(const Negate<Expression>& negate) override;
+    any Visit(const Derivative<Expression, Expression>& derivative) override;
+    any Visit(const Integral<Expression, Expression>& integral) override;
+    any Visit(const Matrix& matrix) override;
+    any Visit(const EulerNumber&) override;
+    any Visit(const Pi&) override;
+    any Visit(const Magnitude<Expression>& magnitude) override;
 
 private:
     auto GetOpsOfBinExp(const DerivedFromBinaryExpression auto& visited) -> std::optional<std::pair<std::string, std::string>>;

--- a/io/include/Oasis/InFixSerializer.hpp
+++ b/io/include/Oasis/InFixSerializer.hpp
@@ -41,8 +41,8 @@ private:
 auto InFixSerializer::GetOpsOfBinExp(const DerivedFromBinaryExpression auto& visited) -> std::expected<std::pair<std::string, std::string>, std::string_view>
 {
     InFixSerializer& thisSerializer = *this;
-    return visited.GetMostSigOp().Accept(thisSerializer).and_then([&thisSerializer, &visited](const auto& mostSigOpStr) {
-        return visited.GetLeastSigOp().Accept(thisSerializer).transform([&mostSigOpStr](const auto& leastSigOpStr) {
+    return visited.GetMostSigOp().Accept(thisSerializer).and_then([&thisSerializer, &visited](const std::string& mostSigOpStr) {
+        return visited.GetLeastSigOp().Accept(thisSerializer).transform([&mostSigOpStr](const std::string& leastSigOpStr) {
             return std::pair { mostSigOpStr, leastSigOpStr };
         });
     });

--- a/io/include/Oasis/MathMLSerializer.hpp
+++ b/io/include/Oasis/MathMLSerializer.hpp
@@ -5,6 +5,7 @@
 #ifndef MATHMLSERIALIZER_HPP
 #define MATHMLSERIALIZER_HPP
 
+#include <gsl/pointers>
 #include <tinyxml2.h>
 
 #include "Oasis/BinaryExpression.hpp"
@@ -13,49 +14,43 @@
 
 namespace Oasis {
 
-class MathMLSerializer final : public Visitor {
+class MathMLSerializer final : public TypedVisitor<std::expected<gsl::not_null<tinyxml2::XMLElement*>, std::string_view>> {
 public:
     explicit MathMLSerializer(tinyxml2::XMLDocument& doc);
-    using RetT = tinyxml2::XMLElement*;
 
-    auto Visit(const Real& real) -> any override;
-    auto Visit(const Imaginary& imaginary) -> any override;
-    auto Visit(const Matrix& matrix) -> any override;
-    auto Visit(const Variable& variable) -> any override;
-    auto Visit(const Undefined& undefined) -> any override;
-    auto Visit(const Pi&) -> any override;
-    auto Visit(const EulerNumber&) -> any override;
-    auto Visit(const Add<Expression, Expression>& add) -> any override;
-    auto Visit(const Subtract<Expression, Expression>& subtract) -> any override;
-    auto Visit(const Multiply<Expression, Expression>& multiply) -> any override;
-    auto Visit(const Divide<Expression, Expression>& divide) -> any override;
-    auto Visit(const Exponent<Expression, Expression>& exponent) -> any override;
-    auto Visit(const Log<Expression, Expression>& log) -> any override;
-    auto Visit(const Negate<Expression>& negate) -> any override;
-    auto Visit(const Magnitude<Expression>& magnitude) -> any override;
-    auto Visit(const Derivative<Expression, Expression>& derivative) -> any override;
-    auto Visit(const Integral<Expression, Expression>& integral) -> any override;
+    auto TypedVisit(const Real& real)-> RetT override;
+    auto TypedVisit(const Imaginary& imaginary)-> RetT override;
+    auto TypedVisit(const Matrix& matrix)-> RetT override;
+    auto TypedVisit(const Variable& variable)-> RetT override;
+    auto TypedVisit(const Undefined& undefined)-> RetT override;
+    auto TypedVisit(const Pi&)-> RetT override;
+    auto TypedVisit(const EulerNumber&)-> RetT override;
+    auto TypedVisit(const Add<Expression, Expression>& add)-> RetT override;
+    auto TypedVisit(const Subtract<Expression, Expression>& subtract)-> RetT override;
+    auto TypedVisit(const Multiply<Expression, Expression>& multiply)-> RetT override;
+    auto TypedVisit(const Divide<Expression, Expression>& divide)-> RetT override;
+    auto TypedVisit(const Exponent<Expression, Expression>& exponent)-> RetT override;
+    auto TypedVisit(const Log<Expression, Expression>& log)-> RetT override;
+    auto TypedVisit(const Negate<Expression>& negate)-> RetT override;
+    auto TypedVisit(const Magnitude<Expression>& magnitude)-> RetT override;
+    auto TypedVisit(const Derivative<Expression, Expression>& derivative)-> RetT override;
+    auto TypedVisit(const Integral<Expression, Expression>& integral)-> RetT override;
 
     [[nodiscard]] tinyxml2::XMLDocument& GetDocument() const;
 
 private:
-    [[nodiscard]] tinyxml2::XMLElement* CreatePlaceholder() const;
-    auto GetOpsAsMathMLPair(const DerivedFromBinaryExpression auto& binexp) -> std::pair<tinyxml2::XMLElement*, tinyxml2::XMLElement*>;
-
+    auto GetOpsAsMathMLPair(const DerivedFromBinaryExpression auto& binexp) -> std::expected<std::pair<gsl::not_null<tinyxml2::XMLElement*>, gsl::not_null<tinyxml2::XMLElement*>>, std::string_view>;
     tinyxml2::XMLDocument& doc;
 };
 
-auto MathMLSerializer::GetOpsAsMathMLPair(const DerivedFromBinaryExpression auto& binexp) -> std::pair<tinyxml2::XMLElement*, tinyxml2::XMLElement*>
+auto MathMLSerializer::GetOpsAsMathMLPair(const DerivedFromBinaryExpression auto& binexp) -> std::expected<std::pair<gsl::not_null<tinyxml2::XMLElement*>, gsl::not_null<tinyxml2::XMLElement*>>, std::string_view>
 {
-    tinyxml2::XMLElement* mostSig = CreatePlaceholder();
-    if (binexp.HasMostSigOp())
-        mostSig = binexp.GetMostSigOp().Accept(*this).value();
-
-    tinyxml2::XMLElement* leastSig = CreatePlaceholder();
-    if (binexp.HasLeastSigOp())
-        leastSig = binexp.GetLeastSigOp().Accept(*this).value();
-
-    return { mostSig, leastSig };
+    MathMLSerializer& thisSerializer = *this;
+    return binexp.GetMostSigOp().Accept(thisSerializer).and_then([&binexp, &thisSerializer](gsl::not_null<tinyxml2::XMLElement*> mostSigOp) {
+        return binexp.GetLeastSigOp().Accept(thisSerializer).transform([&mostSigOp](gsl::not_null<tinyxml2::XMLElement*> leastSigOp) {
+            return std::pair { mostSigOp, leastSigOp };
+        });
+    });
 }
 
 }

--- a/io/include/Oasis/MathMLSerializer.hpp
+++ b/io/include/Oasis/MathMLSerializer.hpp
@@ -18,23 +18,23 @@ public:
     explicit MathMLSerializer(tinyxml2::XMLDocument& doc);
     using RetT = tinyxml2::XMLElement*;
 
-    std::any Visit(const Real& real) override;
-    std::any Visit(const Imaginary& imaginary) override;
-    std::any Visit(const Matrix& matrix) override;
-    std::any Visit(const Variable& variable) override;
-    std::any Visit(const Undefined& undefined) override;
-    std::any Visit(const Pi&) override;
-    std::any Visit(const EulerNumber&) override;
-    std::any Visit(const Add<Expression, Expression>& add) override;
-    std::any Visit(const Subtract<Expression, Expression>& subtract) override;
-    std::any Visit(const Multiply<Expression, Expression>& multiply) override;
-    std::any Visit(const Divide<Expression, Expression>& divide) override;
-    std::any Visit(const Exponent<Expression, Expression>& exponent) override;
-    std::any Visit(const Log<Expression, Expression>& log) override;
-    std::any Visit(const Negate<Expression>& negate) override;
-    std::any Visit(const Magnitude<Expression>& magnitude) override;
-    std::any Visit(const Derivative<Expression, Expression>& derivative) override;
-    std::any Visit(const Integral<Expression, Expression>& integral) override;
+    auto Visit(const Real& real) -> any override;
+    auto Visit(const Imaginary& imaginary) -> any override;
+    auto Visit(const Matrix& matrix) -> any override;
+    auto Visit(const Variable& variable) -> any override;
+    auto Visit(const Undefined& undefined) -> any override;
+    auto Visit(const Pi&) -> any override;
+    auto Visit(const EulerNumber&) -> any override;
+    auto Visit(const Add<Expression, Expression>& add) -> any override;
+    auto Visit(const Subtract<Expression, Expression>& subtract) -> any override;
+    auto Visit(const Multiply<Expression, Expression>& multiply) -> any override;
+    auto Visit(const Divide<Expression, Expression>& divide) -> any override;
+    auto Visit(const Exponent<Expression, Expression>& exponent) -> any override;
+    auto Visit(const Log<Expression, Expression>& log) -> any override;
+    auto Visit(const Negate<Expression>& negate) -> any override;
+    auto Visit(const Magnitude<Expression>& magnitude) -> any override;
+    auto Visit(const Derivative<Expression, Expression>& derivative) -> any override;
+    auto Visit(const Integral<Expression, Expression>& integral) -> any override;
 
     [[nodiscard]] tinyxml2::XMLDocument& GetDocument() const;
 

--- a/io/include/Oasis/MathMLSerializer.hpp
+++ b/io/include/Oasis/MathMLSerializer.hpp
@@ -18,23 +18,23 @@ class MathMLSerializer final : public TypedVisitor<std::expected<gsl::not_null<t
 public:
     explicit MathMLSerializer(tinyxml2::XMLDocument& doc);
 
-    auto TypedVisit(const Real& real)-> RetT override;
-    auto TypedVisit(const Imaginary& imaginary)-> RetT override;
-    auto TypedVisit(const Matrix& matrix)-> RetT override;
-    auto TypedVisit(const Variable& variable)-> RetT override;
-    auto TypedVisit(const Undefined& undefined)-> RetT override;
-    auto TypedVisit(const Pi&)-> RetT override;
-    auto TypedVisit(const EulerNumber&)-> RetT override;
-    auto TypedVisit(const Add<Expression, Expression>& add)-> RetT override;
-    auto TypedVisit(const Subtract<Expression, Expression>& subtract)-> RetT override;
-    auto TypedVisit(const Multiply<Expression, Expression>& multiply)-> RetT override;
-    auto TypedVisit(const Divide<Expression, Expression>& divide)-> RetT override;
-    auto TypedVisit(const Exponent<Expression, Expression>& exponent)-> RetT override;
-    auto TypedVisit(const Log<Expression, Expression>& log)-> RetT override;
-    auto TypedVisit(const Negate<Expression>& negate)-> RetT override;
-    auto TypedVisit(const Magnitude<Expression>& magnitude)-> RetT override;
-    auto TypedVisit(const Derivative<Expression, Expression>& derivative)-> RetT override;
-    auto TypedVisit(const Integral<Expression, Expression>& integral)-> RetT override;
+    auto TypedVisit(const Real& real) -> RetT override;
+    auto TypedVisit(const Imaginary& imaginary) -> RetT override;
+    auto TypedVisit(const Matrix& matrix) -> RetT override;
+    auto TypedVisit(const Variable& variable) -> RetT override;
+    auto TypedVisit(const Undefined& undefined) -> RetT override;
+    auto TypedVisit(const Pi&) -> RetT override;
+    auto TypedVisit(const EulerNumber&) -> RetT override;
+    auto TypedVisit(const Add<Expression, Expression>& add) -> RetT override;
+    auto TypedVisit(const Subtract<Expression, Expression>& subtract) -> RetT override;
+    auto TypedVisit(const Multiply<Expression, Expression>& multiply) -> RetT override;
+    auto TypedVisit(const Divide<Expression, Expression>& divide) -> RetT override;
+    auto TypedVisit(const Exponent<Expression, Expression>& exponent) -> RetT override;
+    auto TypedVisit(const Log<Expression, Expression>& log) -> RetT override;
+    auto TypedVisit(const Negate<Expression>& negate) -> RetT override;
+    auto TypedVisit(const Magnitude<Expression>& magnitude) -> RetT override;
+    auto TypedVisit(const Derivative<Expression, Expression>& derivative) -> RetT override;
+    auto TypedVisit(const Integral<Expression, Expression>& integral) -> RetT override;
 
     [[nodiscard]] tinyxml2::XMLDocument& GetDocument() const;
 

--- a/io/include/Oasis/TeXSerializer.hpp
+++ b/io/include/Oasis/TeXSerializer.hpp
@@ -75,23 +75,23 @@ public:
     void AddTeXPackage(TeXOpts::Pkgs package);
     void RemoveTeXPackage(TeXOpts::Pkgs package);
 
-    std::any Visit(const Real& real) override;
-    std::any Visit(const Imaginary& imaginary) override;
-    std::any Visit(const Matrix& matrix) override;
-    std::any Visit(const Variable& variable) override;
-    std::any Visit(const Undefined& undefined) override;
-    std::any Visit(const Pi&) override;
-    std::any Visit(const EulerNumber&) override;
-    std::any Visit(const Add<Expression, Expression>& add) override;
-    std::any Visit(const Subtract<Expression, Expression>& subtract) override;
-    std::any Visit(const Multiply<Expression, Expression>& multiply) override;
-    std::any Visit(const Divide<Expression, Expression>& divide) override;
-    std::any Visit(const Exponent<Expression, Expression>& exponent) override;
-    std::any Visit(const Log<Expression, Expression>& log) override;
-    std::any Visit(const Negate<Expression>& negate) override;
-    std::any Visit(const Magnitude<Expression>& magnitude) override;
-    std::any Visit(const Derivative<Expression, Expression>& derivative) override;
-    std::any Visit(const Integral<Expression, Expression>& integral) override;
+    auto Visit(const Real& real) -> any override;
+    auto Visit(const Imaginary& imaginary) -> any override;
+    auto Visit(const Matrix& matrix) -> any override;
+    auto Visit(const Variable& variable) -> any override;
+    auto Visit(const Undefined& undefined) -> any override;
+    auto Visit(const Pi&) -> any override;
+    auto Visit(const EulerNumber&) -> any override;
+    auto Visit(const Add<Expression, Expression>& add) -> any override;
+    auto Visit(const Subtract<Expression, Expression>& subtract) -> any override;
+    auto Visit(const Multiply<Expression, Expression>& multiply) -> any override;
+    auto Visit(const Divide<Expression, Expression>& divide) -> any override;
+    auto Visit(const Exponent<Expression, Expression>& exponent) -> any override;
+    auto Visit(const Log<Expression, Expression>& log) -> any override;
+    auto Visit(const Negate<Expression>& negate) -> any override;
+    auto Visit(const Magnitude<Expression>& magnitude) -> any override;
+    auto Visit(const Derivative<Expression, Expression>& derivative) -> any override;
+    auto Visit(const Integral<Expression, Expression>& integral) -> any override;
 
 private:
     TeXOpts latexOptions {};

--- a/io/src/FromString.cpp
+++ b/io/src/FromString.cpp
@@ -296,7 +296,8 @@ auto FromInFix(const std::string& str, ParseImaginaryOption option) -> std::expe
         }
     }
 
-    if (st.empty()) return std::unexpected { "Parsing failed" };
+    if (st.empty())
+        return std::unexpected { "Parsing failed" };
     return st.top()->Copy(); // root of the expression tree
 }
 

--- a/io/src/InFixSerializer.cpp
+++ b/io/src/InFixSerializer.cpp
@@ -21,99 +21,93 @@
 
 namespace Oasis {
 
-any InFixSerializer::Visit(const Real& real)
+auto InFixSerializer::TypedVisit(const Real& real) -> RetT
 {
-    return std::format("{:.5}", real.GetValue());
+    return std::expected<std::string, std::string_view> { std::format("{:.5}", real.GetValue()) };
 }
 
-any InFixSerializer::Visit(const Imaginary&)
+auto InFixSerializer::TypedVisit(const Imaginary&) -> RetT
 {
     return "i";
 }
 
-any InFixSerializer::Visit(const Variable& variable)
+auto InFixSerializer::TypedVisit(const Variable& variable) -> RetT
 {
     return variable.GetName();
 }
 
-any InFixSerializer::Visit(const Undefined&)
+auto InFixSerializer::TypedVisit(const Undefined&) -> RetT
 {
     return "Undefined";
 }
 
-any InFixSerializer::Visit(const Add<>& add)
+auto InFixSerializer::TypedVisit(const Add<>& add) -> RetT
 {
-    auto result = SerializeArithBinExp(add, "+");
-    return result ? result.value() : any {};
+    return SerializeArithBinExp(add, "+");
 }
 
-any InFixSerializer::Visit(const Subtract<>& subtract)
+auto InFixSerializer::TypedVisit(const Subtract<>& subtract) -> RetT
 {
-    auto result = SerializeArithBinExp(subtract, "-");
-    return result ? result.value() : any {};
+    return SerializeArithBinExp(subtract, "-");
 }
 
-any InFixSerializer::Visit(const Multiply<>& multiply)
+auto InFixSerializer::TypedVisit(const Multiply<>& multiply) -> RetT
 {
-    auto result = SerializeArithBinExp(multiply, "*");
-    return result ? result.value() : any {};
+    return SerializeArithBinExp(multiply, "*");
 }
 
-any InFixSerializer::Visit(const Divide<>& divide)
+auto InFixSerializer::TypedVisit(const Divide<>& divide) -> RetT
 {
-    auto result = SerializeArithBinExp(divide, "/");
-    return result ? result.value() : any {};
+    return SerializeArithBinExp(divide, "/");
 }
 
-any InFixSerializer::Visit(const Exponent<>& exponent)
+auto InFixSerializer::TypedVisit(const Exponent<>& exponent) -> RetT
 {
-    auto result = SerializeArithBinExp(exponent, "^");
-    return result ? result.value() : any {};
+    return SerializeArithBinExp(exponent, "^");
 }
 
-any InFixSerializer::Visit(const Log<>& log)
+auto InFixSerializer::TypedVisit(const Log<>& log) -> RetT
 {
-    auto result = SerializeArithBinExp(log, "log");
-    return result ? result.value() : any {};
+    return SerializeArithBinExp(log, "log");
 }
 
-any InFixSerializer::Visit(const Negate<Expression>& negate)
+auto InFixSerializer::TypedVisit(const Negate<Expression>& negate) -> RetT
 {
-    auto opStr = negate.GetOperand().Accept(*this);
-    return opStr ? std::format("-({})", opStr.value()) : any {};
+    return negate.GetOperand().Accept(*this).transform([](const std::string& str) {
+        return std::format("-({})", str);
+    });
 }
 
-any InFixSerializer::Visit(const Derivative<>& derivative)
+auto InFixSerializer::TypedVisit(const Derivative<>& derivative) -> RetT
 {
-    auto result = SerializeFuncBinExp(derivative, "dd");
-    return result ? result.value() : any {};
+    return SerializeFuncBinExp(derivative, "dd");
 }
 
-any InFixSerializer::Visit(const Integral<>& integral)
+auto InFixSerializer::TypedVisit(const Integral<>& integral) -> RetT
 {
-    auto result = SerializeFuncBinExp(integral, "in");
-    return result ? result.value() : any {};
+    return SerializeFuncBinExp(integral, "in");
 }
 
-any InFixSerializer::Visit(const Matrix&)
+auto InFixSerializer::TypedVisit(const Matrix&) -> RetT
 {
-    return "NOT IMPLEMENTED";
+    return std::unexpected { "NOT IMPLEMENTED" };
 }
 
-any InFixSerializer::Visit(const EulerNumber&)
+auto InFixSerializer::TypedVisit(const EulerNumber&) -> RetT
 {
     return "e";
 }
 
-any InFixSerializer::Visit(const Pi&)
+auto InFixSerializer::TypedVisit(const Pi&) -> RetT
 {
     return "pi";
 }
 
-any InFixSerializer::Visit(const Magnitude<Expression>& magnitude)
+auto InFixSerializer::TypedVisit(const Magnitude<Expression>& magnitude) -> RetT
 {
-    const auto opStr = magnitude.GetOperand().Accept(*this);
-    return opStr ? std::format("|({})|", opStr.value()) : any {};
+    return magnitude.GetOperand().Accept(*this).transform([](const std::string& str) {
+        return std::format("|{}|", str);
+    });
 }
 
 } // Oasis

--- a/io/src/InFixSerializer.cpp
+++ b/io/src/InFixSerializer.cpp
@@ -21,99 +21,99 @@
 
 namespace Oasis {
 
-std::any InFixSerializer::Visit(const Real& real)
+any InFixSerializer::Visit(const Real& real)
 {
     return std::format("{:.5}", real.GetValue());
 }
 
-std::any InFixSerializer::Visit(const Imaginary&)
+any InFixSerializer::Visit(const Imaginary&)
 {
     return "i";
 }
 
-std::any InFixSerializer::Visit(const Variable& variable)
+any InFixSerializer::Visit(const Variable& variable)
 {
     return variable.GetName();
 }
 
-std::any InFixSerializer::Visit(const Undefined&)
+any InFixSerializer::Visit(const Undefined&)
 {
     return "Undefined";
 }
 
-std::any InFixSerializer::Visit(const Add<>& add)
+any InFixSerializer::Visit(const Add<>& add)
 {
     auto result = SerializeArithBinExp(add, "+");
-    return result ? result.value() : std::any {};
+    return result ? result.value() : any {};
 }
 
-std::any InFixSerializer::Visit(const Subtract<>& subtract)
+any InFixSerializer::Visit(const Subtract<>& subtract)
 {
     auto result = SerializeArithBinExp(subtract, "-");
-    return result ? result.value() : std::any {};
+    return result ? result.value() : any {};
 }
 
-std::any InFixSerializer::Visit(const Multiply<>& multiply)
+any InFixSerializer::Visit(const Multiply<>& multiply)
 {
     auto result = SerializeArithBinExp(multiply, "*");
-    return result ? result.value() : std::any {};
+    return result ? result.value() : any {};
 }
 
-std::any InFixSerializer::Visit(const Divide<>& divide)
+any InFixSerializer::Visit(const Divide<>& divide)
 {
     auto result = SerializeArithBinExp(divide, "/");
-    return result ? result.value() : std::any {};
+    return result ? result.value() : any {};
 }
 
-std::any InFixSerializer::Visit(const Exponent<>& exponent)
+any InFixSerializer::Visit(const Exponent<>& exponent)
 {
     auto result = SerializeArithBinExp(exponent, "^");
-    return result ? result.value() : std::any {};
+    return result ? result.value() : any {};
 }
 
-std::any InFixSerializer::Visit(const Log<>& log)
+any InFixSerializer::Visit(const Log<>& log)
 {
     auto result = SerializeArithBinExp(log, "log");
-    return result ? result.value() : std::any {};
+    return result ? result.value() : any {};
 }
 
-std::any InFixSerializer::Visit(const Negate<Expression>& negate)
+any InFixSerializer::Visit(const Negate<Expression>& negate)
 {
     auto opStr = negate.GetOperand().Accept(*this);
-    return opStr ? std::format("-({})", opStr.value()) : std::any {};
+    return opStr ? std::format("-({})", opStr.value()) : any {};
 }
 
-std::any InFixSerializer::Visit(const Derivative<>& derivative)
+any InFixSerializer::Visit(const Derivative<>& derivative)
 {
     auto result = SerializeFuncBinExp(derivative, "dd");
-    return result ? result.value() : std::any {};
+    return result ? result.value() : any {};
 }
 
-std::any InFixSerializer::Visit(const Integral<>& integral)
+any InFixSerializer::Visit(const Integral<>& integral)
 {
     auto result = SerializeFuncBinExp(integral, "in");
-    return result ? result.value() : std::any {};
+    return result ? result.value() : any {};
 }
 
-std::any InFixSerializer::Visit(const Matrix&)
+any InFixSerializer::Visit(const Matrix&)
 {
     return "NOT IMPLEMENTED";
 }
 
-std::any InFixSerializer::Visit(const EulerNumber&)
+any InFixSerializer::Visit(const EulerNumber&)
 {
     return "e";
 }
 
-std::any InFixSerializer::Visit(const Pi&)
+any InFixSerializer::Visit(const Pi&)
 {
     return "pi";
 }
 
-std::any InFixSerializer::Visit(const Magnitude<Expression>& magnitude)
+any InFixSerializer::Visit(const Magnitude<Expression>& magnitude)
 {
     const auto opStr = magnitude.GetOperand().Accept(*this);
-    return opStr ? std::format("|({})|", opStr.value()) : std::any {};
+    return opStr ? std::format("|({})|", opStr.value()) : any {};
 }
 
 } // Oasis

--- a/io/src/MathMLSerializer.cpp
+++ b/io/src/MathMLSerializer.cpp
@@ -280,33 +280,33 @@ auto MathMLSerializer::TypedVisit(const Log<>& log) -> RetT
 {
     return GetOpsAsMathMLPair(log).transform([this, log](const auto& ops) {
         // mrow
-         tinyxml2::XMLElement* const mrow = doc.NewElement("mrow");
+        tinyxml2::XMLElement* const mrow = doc.NewElement("mrow");
 
-         // log
-         tinyxml2::XMLElement* const msub = doc.NewElement("msub");
+        // log
+        tinyxml2::XMLElement* const msub = doc.NewElement("msub");
 
-         tinyxml2::XMLElement* const logElement = doc.NewElement("mi");
-         logElement->SetText("log");
+        tinyxml2::XMLElement* const logElement = doc.NewElement("mi");
+        logElement->SetText("log");
 
-         auto [baseElement, argElement] = ops;
+        auto [baseElement, argElement] = ops;
 
-         msub->InsertFirstChild(logElement);
-         msub->InsertEndChild(baseElement);
-         mrow->InsertFirstChild(msub);
+        msub->InsertFirstChild(logElement);
+        msub->InsertEndChild(baseElement);
+        mrow->InsertFirstChild(msub);
 
-         // (
-         tinyxml2::XMLElement* const leftParen = doc.NewElement("mo");
-         leftParen->SetText("(");
+        // (
+        tinyxml2::XMLElement* const leftParen = doc.NewElement("mo");
+        leftParen->SetText("(");
 
-         // )
-         tinyxml2::XMLElement* const rightParen = doc.NewElement("mo");
-         rightParen->SetText(")");
+        // )
+        tinyxml2::XMLElement* const rightParen = doc.NewElement("mo");
+        rightParen->SetText(")");
 
-         mrow->InsertEndChild(leftParen);
-         mrow->InsertEndChild(argElement);
-         mrow->InsertEndChild(rightParen);
+        mrow->InsertEndChild(leftParen);
+        mrow->InsertEndChild(argElement);
+        mrow->InsertEndChild(rightParen);
 
-         return mrow;
+        return mrow;
     });
 }
 

--- a/io/src/MathMLSerializer.cpp
+++ b/io/src/MathMLSerializer.cpp
@@ -29,21 +29,21 @@ MathMLSerializer::MathMLSerializer(tinyxml2::XMLDocument& doc)
 {
 }
 
-std::any MathMLSerializer::Visit(const Real& real)
+any MathMLSerializer::Visit(const Real& real)
 {
     tinyxml2::XMLElement* result = doc.NewElement("mn");
     result->SetText(std::format("{:.5}", real.GetValue()).c_str());
     return result;
 }
 
-std::any MathMLSerializer::Visit(const Imaginary&)
+any MathMLSerializer::Visit(const Imaginary&)
 {
     tinyxml2::XMLElement* result = doc.NewElement("mi");
     result->SetText("i");
     return result;
 }
 
-std::any MathMLSerializer::Visit(const Matrix& matrix)
+any MathMLSerializer::Visit(const Matrix& matrix)
 {
     tinyxml2::XMLElement* mrow = doc.NewElement("mrow");
 
@@ -75,35 +75,35 @@ std::any MathMLSerializer::Visit(const Matrix& matrix)
     return mrow;
 }
 
-std::any MathMLSerializer::Visit(const Oasis::Pi&)
+any MathMLSerializer::Visit(const Oasis::Pi&)
 {
     tinyxml2::XMLElement* result = doc.NewElement("mi");
     result->SetText("&pi;");
     return result;
 }
 
-std::any MathMLSerializer::Visit(const Oasis::EulerNumber&)
+any MathMLSerializer::Visit(const Oasis::EulerNumber&)
 {
     tinyxml2::XMLElement* result = doc.NewElement("mi");
     result->SetText("e");
     return result;
 }
 
-std::any MathMLSerializer::Visit(const Variable& variable)
+any MathMLSerializer::Visit(const Variable& variable)
 {
     tinyxml2::XMLElement* result = doc.NewElement("mi");
     result->SetText(variable.GetName().c_str());
     return result;
 }
 
-std::any MathMLSerializer::Visit(const Undefined&)
+any MathMLSerializer::Visit(const Undefined&)
 {
     tinyxml2::XMLElement* const mtext = doc.NewElement("mtext");
     mtext->SetText("Undefined");
     return mtext;
 }
 
-std::any MathMLSerializer::Visit(const Add<>& add)
+any MathMLSerializer::Visit(const Add<>& add)
 {
     tinyxml2::XMLElement* mrow = doc.NewElement("mrow");
 
@@ -125,7 +125,7 @@ std::any MathMLSerializer::Visit(const Add<>& add)
     return mrow;
 }
 
-std::any MathMLSerializer::Visit(const Subtract<>& subtract)
+any MathMLSerializer::Visit(const Subtract<>& subtract)
 {
     // mrow
     tinyxml2::XMLElement* const mrow = doc.NewElement("mrow");
@@ -168,7 +168,7 @@ std::any MathMLSerializer::Visit(const Subtract<>& subtract)
     return mrow;
 }
 
-std::any MathMLSerializer::Visit(const Multiply<>& multiply)
+any MathMLSerializer::Visit(const Multiply<>& multiply)
 {
     tinyxml2::XMLElement* mrow = doc.NewElement("mrow");
 
@@ -228,7 +228,7 @@ std::any MathMLSerializer::Visit(const Multiply<>& multiply)
     return mrow;
 }
 
-std::any MathMLSerializer::Visit(const Divide<>& divide)
+any MathMLSerializer::Visit(const Divide<>& divide)
 {
     tinyxml2::XMLElement* mfrac = doc.NewElement("mfrac");
 
@@ -240,7 +240,7 @@ std::any MathMLSerializer::Visit(const Divide<>& divide)
     return mfrac;
 }
 
-std::any MathMLSerializer::Visit(const Exponent<>& exponent)
+any MathMLSerializer::Visit(const Exponent<>& exponent)
 {
     tinyxml2::XMLElement* msup = doc.NewElement("msup");
 
@@ -271,7 +271,7 @@ std::any MathMLSerializer::Visit(const Exponent<>& exponent)
     return msup;
 }
 
-std::any MathMLSerializer::Visit(const Log<>& log)
+any MathMLSerializer::Visit(const Log<>& log)
 {
     // mrow
     tinyxml2::XMLElement* const mrow = doc.NewElement("mrow");
@@ -303,7 +303,7 @@ std::any MathMLSerializer::Visit(const Log<>& log)
     return mrow;
 }
 
-std::any MathMLSerializer::Visit(const Negate<Expression>& negate)
+any MathMLSerializer::Visit(const Negate<Expression>& negate)
 {
     // mrow
     tinyxml2::XMLElement* const mrow = doc.NewElement("mrow");
@@ -329,7 +329,7 @@ std::any MathMLSerializer::Visit(const Negate<Expression>& negate)
     return mrow;
 }
 
-std::any MathMLSerializer::Visit(const Derivative<>& derivative)
+any MathMLSerializer::Visit(const Derivative<>& derivative)
 {
     tinyxml2::XMLElement* mrow = doc.NewElement("mrow");
 
@@ -367,7 +367,7 @@ std::any MathMLSerializer::Visit(const Derivative<>& derivative)
     return mrow;
 }
 
-std::any MathMLSerializer::Visit(const Integral<>& integral)
+any MathMLSerializer::Visit(const Integral<>& integral)
 {
     tinyxml2::XMLElement* mrow = doc.NewElement("mrow");
 
@@ -406,7 +406,7 @@ tinyxml2::XMLElement* MathMLSerializer::CreatePlaceholder() const
     return mspace;
 }
 
-std::any MathMLSerializer::Visit(const Magnitude<Expression>& magnitude)
+any MathMLSerializer::Visit(const Magnitude<Expression>& magnitude)
 {
     // mrow
     tinyxml2::XMLElement* const mrow = doc.NewElement("mrow");
@@ -416,7 +416,7 @@ std::any MathMLSerializer::Visit(const Magnitude<Expression>& magnitude)
     leftParen->SetText("|");
     mrow->InsertEndChild(leftParen);
 
-    const auto operandElement = std::any_cast<tinyxml2::XMLElement*>(magnitude.GetOperand().Accept(*this));
+    const auto operandElement = magnitude.GetOperand().Accept(*this).value();
     mrow->InsertEndChild(operandElement);
 
     // )

--- a/io/src/TeXSerializer.cpp
+++ b/io/src/TeXSerializer.cpp
@@ -174,7 +174,7 @@ auto TeXSerializer::TypedVisit(const Exponent<Expression, Expression>& exponent)
 
 auto TeXSerializer::TypedVisit(const Log<Expression, Expression>& log) -> RetT
 {
-    return GetOpsOfBinExp(log).transform([this](const std::pair<std::string, std::string>& ops) {
+    return GetOpsOfBinExp(log).transform([](const std::pair<std::string, std::string>& ops) {
         return std::format("\\log_{{{}}}\\left({}\\right)", ops.first, ops.second);
     });
 }
@@ -195,14 +195,14 @@ auto TeXSerializer::TypedVisit(const Magnitude<Expression>& magnitude) -> RetT
 
 auto TeXSerializer::TypedVisit(const Derivative<Expression, Expression>& derivative) -> RetT
 {
-    return GetOpsOfBinExp(derivative).transform([this](const std::pair<std::string, std::string>& ops) {
+    return GetOpsOfBinExp(derivative).transform([](const std::pair<std::string, std::string>& ops) {
         return std::format("\\frac{{d}}{{d{}}}\\left({}\\right)", ops.first, ops.second);
     });
 }
 
 auto TeXSerializer::TypedVisit(const Integral<Expression, Expression>& integral) -> RetT
 {
-    return GetOpsOfBinExp(integral).transform([this](const std::pair<std::string, std::string>& ops) {
+    return GetOpsOfBinExp(integral).transform([](const std::pair<std::string, std::string>& ops) {
         return std::format("\\int\\left({}\\right)d{}", ops.first, ops.second);
     });
 }

--- a/io/src/TeXSerializer.cpp
+++ b/io/src/TeXSerializer.cpp
@@ -167,7 +167,7 @@ auto TeXSerializer::TypedVisit(const Divide<Expression, Expression>& divide) -> 
 
 auto TeXSerializer::TypedVisit(const Exponent<Expression, Expression>& exponent) -> RetT
 {
-    return GetOpsOfBinExp(exponent).transform([this](const std::pair<std::string, std::string>& ops) {
+    return GetOpsOfBinExp(exponent).transform([](const std::pair<std::string, std::string>& ops) {
         return std::format("\\left({}\\right)^{{{}}}", ops.first, ops.second);
     });
 }

--- a/io/src/TeXSerializer.cpp
+++ b/io/src/TeXSerializer.cpp
@@ -80,13 +80,13 @@ void TeXSerializer::RemoveTeXPackage(TeXOpts::Pkgs package)
     latexOptions.packages.erase(package);
 }
 
-std::any TeXSerializer::Visit(const Real& real)
+any TeXSerializer::Visit(const Real& real)
 {
     auto result = std::format("{:.{}}", real.GetValue(), latexOptions.numPlaces + 1);
     return result;
 }
 
-std::any TeXSerializer::Visit(const Imaginary&)
+any TeXSerializer::Visit(const Imaginary&)
 {
     switch (latexOptions.character) {
     case TeXOpts::ImgSym::J:
@@ -98,7 +98,7 @@ std::any TeXSerializer::Visit(const Imaginary&)
     return {};
 }
 
-std::any TeXSerializer::Visit(const Matrix& matrix)
+any TeXSerializer::Visit(const Matrix& matrix)
 {
     std::string result = "\\begin{bmatrix}\n";
     MatrixXXD mat = matrix.GetMatrix();
@@ -118,45 +118,45 @@ std::any TeXSerializer::Visit(const Matrix& matrix)
     return result;
 }
 
-std::any TeXSerializer::Visit(const Variable& variable)
+any TeXSerializer::Visit(const Variable& variable)
 {
     return variable.GetName();
 }
 
-std::any TeXSerializer::Visit(const Undefined&)
+any TeXSerializer::Visit(const Undefined&)
 {
     return std::string { "Undefined" };
 }
 
-std::any TeXSerializer::Visit(const Pi&)
+any TeXSerializer::Visit(const Pi&)
 {
     return std::string { "\\pi" };
 }
 
-std::any TeXSerializer::Visit(const EulerNumber&)
+any TeXSerializer::Visit(const EulerNumber&)
 {
     return std::string { "e" };
 }
 
-std::any TeXSerializer::Visit(const Add<Expression, Expression>& add)
+any TeXSerializer::Visit(const Add<Expression, Expression>& add)
 {
     auto result = SerializeArithBinExp(add, "+");
-    return result ? result.value() : std::any {};
+    return result ? result.value() : any {};
 }
 
-std::any TeXSerializer::Visit(const Subtract<Expression, Expression>& subtract)
+any TeXSerializer::Visit(const Subtract<Expression, Expression>& subtract)
 {
     auto result = SerializeArithBinExp(subtract, "-");
-    return result ? result.value() : std::any {};
+    return result ? result.value() : any {};
 }
 
-std::any TeXSerializer::Visit(const Multiply<Expression, Expression>& multiply)
+any TeXSerializer::Visit(const Multiply<Expression, Expression>& multiply)
 {
     auto result = SerializeArithBinExp(multiply, "*");
-    return result ? result.value() : std::any {};
+    return result ? result.value() : any {};
 }
 
-std::any TeXSerializer::Visit(const Divide<Expression, Expression>& divide)
+any TeXSerializer::Visit(const Divide<Expression, Expression>& divide)
 {
     auto ops = GetOpsOfBinExp(divide);
     if (!ops)
@@ -173,7 +173,7 @@ std::any TeXSerializer::Visit(const Divide<Expression, Expression>& divide)
     return {};
 }
 
-std::any TeXSerializer::Visit(const Exponent<Expression, Expression>& exponent)
+any TeXSerializer::Visit(const Exponent<Expression, Expression>& exponent)
 {
     auto ops = GetOpsOfBinExp(exponent);
     if (!ops)
@@ -183,7 +183,7 @@ std::any TeXSerializer::Visit(const Exponent<Expression, Expression>& exponent)
     return std::format("\\left({}\\right)^{{{}}}", mostSigOpStr, leastSigOpStr);
 }
 
-std::any TeXSerializer::Visit(const Log<Expression, Expression>& log)
+any TeXSerializer::Visit(const Log<Expression, Expression>& log)
 {
     // if (log.GetMostSigOp())
     auto ops = GetOpsOfBinExp(log);
@@ -194,19 +194,19 @@ std::any TeXSerializer::Visit(const Log<Expression, Expression>& log)
     return std::format("\\log_{{{}}}\\left({}\\right)", mostSigOpStr, leastSigOpStr);
 }
 
-std::any TeXSerializer::Visit(const Negate<Expression>& negate)
+any TeXSerializer::Visit(const Negate<Expression>& negate)
 {
     const auto op = negate.GetOperand().Accept(*this);
-    return op ? std::format("\\left(-{}\\right)", op.value()) : std::any {};
+    return op ? std::format("\\left(-{}\\right)", op.value()) : any {};
 }
 
-std::any TeXSerializer::Visit(const Magnitude<Expression>& magnitude)
+any TeXSerializer::Visit(const Magnitude<Expression>& magnitude)
 {
     const auto op = magnitude.GetOperand().Accept(*this);
-    return op ? std::format("\\left|{}\\right|", op.value()) : std::any {};
+    return op ? std::format("\\left|{}\\right|", op.value()) : any {};
 }
 
-std::any TeXSerializer::Visit(const Derivative<Expression, Expression>& derivative)
+any TeXSerializer::Visit(const Derivative<Expression, Expression>& derivative)
 {
     auto ops = GetOpsOfBinExp(derivative);
     if (!ops)
@@ -216,7 +216,7 @@ std::any TeXSerializer::Visit(const Derivative<Expression, Expression>& derivati
     return std::format("\\frac{{d}}{{d{}}}\\left({}\\right)", mostSigOpStr, leastSigOpStr);
 }
 
-std::any TeXSerializer::Visit(const Integral<Expression, Expression>& integral)
+any TeXSerializer::Visit(const Integral<Expression, Expression>& integral)
 {
     auto ops = GetOpsOfBinExp(integral);
     if (!ops)

--- a/io/tests/InFixTests.cpp
+++ b/io/tests/InFixTests.cpp
@@ -18,10 +18,10 @@ TEST_CASE("In-Fix Parsing Works for Simple Trees", "[Parsing]")
     };
 
     const auto result = Oasis::FromInFix("1 + 2");
-    REQUIRE(result.Ok());
+    REQUIRE(result.has_value());
 
-    const auto& parsed = result.GetResult();
-    REQUIRE(parsed.Equals(expected));
+    const auto& parsed = result.value();
+    REQUIRE(parsed->Equals(expected));
 }
 
 TEST_CASE("In-Fix Parsing Respects Order of Operations", "[Parsing]")
@@ -34,10 +34,10 @@ TEST_CASE("In-Fix Parsing Respects Order of Operations", "[Parsing]")
     };
 
     const auto result = Oasis::FromInFix("1 + 2 * 3");
-    REQUIRE(result.Ok());
+    REQUIRE(result.has_value());
 
-    const auto& parsed = result.GetResult();
-    REQUIRE(parsed.Equals(expected));
+    const auto& parsed = result.value();
+    REQUIRE(parsed->Equals(expected));
 }
 
 TEST_CASE("In-Fix Parsing Works with Functions", "[Parsing]")
@@ -50,10 +50,10 @@ TEST_CASE("In-Fix Parsing Works with Functions", "[Parsing]")
     };
 
     const auto result = Oasis::FromInFix("1 + log ( 2 , 3 )");
-    REQUIRE(result.Ok());
+    REQUIRE(result.has_value());
 
-    const auto& parsed = result.GetResult();
-    REQUIRE(parsed.Equals(expected));
+    const auto& parsed = result.value();
+    REQUIRE(parsed->Equals(expected));
 }
 
 TEST_CASE("In-Fix Parsing Works with Variables", "[Parsing]")
@@ -69,11 +69,11 @@ TEST_CASE("In-Fix Parsing Works with Variables", "[Parsing]")
 
     const auto preprocessed = Oasis::PreProcessInFix("1x+y3");
     const auto result = Oasis::FromInFix(preprocessed);
-    REQUIRE(result.Ok());
+    REQUIRE(result.has_value());
 
 
-    const auto& parsed = result.GetResult();
-    REQUIRE(parsed.Equals(expected));
+    const auto& parsed = result.value();
+    REQUIRE(parsed->Equals(expected));
 }
 
 TEST_CASE("In-Fix Preprocessor Works", "[Parsing]")

--- a/io/tests/TeXTests.cpp
+++ b/io/tests/TeXTests.cpp
@@ -158,7 +158,7 @@ TEST_CASE("LaTeX Serialization for Negate", "[LaTeX][Serializer][Negate]")
     Oasis::TeXSerializer serializer{};
 
     auto result = e.Accept(serializer).value();
-    std::string expected = R"(\left(-e\right))";
+    std::string expected = R"(-\left(e\right))";
 
     REQUIRE(expected == result);
 

--- a/io/tests/TeXTests.cpp
+++ b/io/tests/TeXTests.cpp
@@ -58,7 +58,7 @@ TEST_CASE("LaTeX Serialization for Addition", "[LaTeX][Serializer][Add]"){
 
     Oasis::TeXSerializer serializer;
 
-    auto result = std::any_cast<std::string>(a.AcceptInternal(serializer));
+    auto result = a.Accept(serializer).value();
     std::string expected = "\\left(5+x_0\\right)";
 
     REQUIRE(expected == result);
@@ -69,7 +69,7 @@ TEST_CASE("LaTeX Serialization for Subtraction", "[LaTeX][Serializer][Subtract]"
 
     Oasis::TeXSerializer serializer;
 
-    auto result = std::any_cast<std::string>(s.AcceptInternal(serializer));
+    auto result = s.Accept(serializer).value();
     std::string expected = "\\left(5-x_0\\right)";
 
     REQUIRE(expected == result);
@@ -81,7 +81,7 @@ TEST_CASE("LaTeX Serialization for Multiplication", "[LaTeX][Serializer][Multipl
 
     Oasis::TeXSerializer serializer;
 
-    auto result = std::any_cast<std::string>(s.AcceptInternal(serializer));
+    auto result = s.Accept(serializer).value();
     std::string expected = "\\left(5*x_0\\right)";
 
     REQUIRE(expected == result);
@@ -93,7 +93,7 @@ TEST_CASE("LaTeX Serialization for Division", "[LaTeX][Serializer][Divide]")
 
     Oasis::TeXSerializer serializer;
 
-    auto result = std::any_cast<std::string>(d.AcceptInternal(serializer));
+    auto result = d.Accept(serializer).value();
     std::string expected = R"(\left(\frac{5}{x_0}\right))";
 
     REQUIRE(expected == result);
@@ -106,7 +106,7 @@ TEST_CASE("LaTeX Serialization for Division with \\div", "[LaTeX][Serializer][Di
     Oasis::TeXSerializer serializer { { .divType = Oasis::TeXOpts::DivType::DIV } };
     assert(serializer.GetDivType() == Oasis::TeXOpts::DivType::DIV);
 
-    auto result = std::any_cast<std::string>(d.AcceptInternal(serializer));
+    auto result = d.Accept(serializer).value();
     std::string expected = R"(\left({5}\div{x_0}\right))";
 
     REQUIRE(expected == result);
@@ -119,7 +119,7 @@ TEST_CASE("LaTeX Serialization with spacing options", "[LaTeX][Serializer][TexOp
     Oasis::TeXOpts options {.spacing = Oasis::TeXOpts::Spacing::REGULAR };
     Oasis::TeXSerializer serializer{options};
 
-    auto result = std::any_cast<std::string>(s.AcceptInternal(serializer));
+    auto result = s.Accept(serializer).value();
     std::string expected = "\\left(5 * x_0\\right)";
 
     REQUIRE(expected == result);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,7 +55,7 @@ if(OASIS_BUILD_PARANOID)
     endif()
 endif()
 
-target_compile_features(Oasis PUBLIC cxx_std_20)
+target_compile_features(Oasis PUBLIC cxx_std_23)
 target_link_libraries(Oasis PUBLIC Oasis::Headers Eigen3::Eigen Boost::any Boost::mpl)
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${Oasis_SOURCES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,6 @@ if(OASIS_BUILD_PARANOID)
 endif()
 
 target_compile_features(Oasis PUBLIC cxx_std_23)
-target_link_libraries(Oasis PUBLIC Oasis::Headers Eigen3::Eigen Boost::any Boost::mpl)
+target_link_libraries(Oasis PUBLIC Oasis::Headers Eigen3::Eigen Boost::any Boost::callable_traits Boost::mpl)
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${Oasis_SOURCES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,7 @@ if(OASIS_BUILD_PARANOID)
 endif()
 
 target_compile_features(Oasis PUBLIC cxx_std_23)
-target_link_libraries(Oasis PUBLIC Oasis::Headers Eigen3::Eigen Boost::any Boost::callable_traits Boost::mpl)
+target_link_libraries(Oasis PUBLIC Oasis::Headers Eigen3::Eigen Boost::any
+                                   Boost::callable_traits Boost::mpl)
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${Oasis_SOURCES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,6 @@ if(OASIS_BUILD_PARANOID)
 endif()
 
 target_compile_features(Oasis PUBLIC cxx_std_20)
-target_link_libraries(Oasis PUBLIC Oasis::Headers Eigen3::Eigen Boost::mpl)
+target_link_libraries(Oasis PUBLIC Oasis::Headers Eigen3::Eigen Boost::any Boost::mpl)
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${Oasis_SOURCES})

--- a/src/Exponent.cpp
+++ b/src/Exponent.cpp
@@ -26,87 +26,85 @@ Exponent<Expression>::Exponent(const Expression& base, const Expression& power)
 auto Exponent<Expression>::Simplify() const -> std::unique_ptr<Expression>
 {
     static auto match_cast = MatchCast<Expression>()
-                                   .Case(
-                                       [](const Exponent<Expression, Real>& zeroCase) -> bool {
-                                           // TODO: Optimize. We're calling RecursiveCast<Expression<Real, Expression> twice. Perhaps a map of expression types to a vector of lambdas?
-                                           const Real& power = zeroCase.GetLeastSigOp();
-                                           return power.GetValue() == 0.0;
-                                        },
-                                        [](const Exponent<Expression, Real>&) -> std::unique_ptr<Expression> {
-                                            return std::make_unique<Real>(1.0);
-                                        }
-                                   )
-                                   .Case(
-                                       [](const Exponent<Real, Expression>& zeroCase) -> bool {
-                                           const Real& base = zeroCase.GetMostSigOp();
-                                           return base.GetValue() == 0.0;
-                                        },
-                                        [](const Exponent<Real, Expression>&) -> std::unique_ptr<Expression> {
-                                            return std::make_unique<Real>(0.0);
-                                        }
-                                   )
-                                   .Case(
-                                       [](const Exponent<Real>&) { return true; },
-                                       [](const Exponent<Real>& realCase) -> std::unique_ptr<Expression> {
-                                       const Real& base = realCase.GetMostSigOp();
-                                       const Real& power = realCase.GetLeastSigOp();
-                                       return std::make_unique<Real>(pow(base.GetValue(), power.GetValue()));
-                                   })
-                                   .Case(
-                                       [](const Exponent<Expression, Real>& oneCase) -> bool {
-                                           const Real& power = oneCase.GetLeastSigOp();
-                                           return power.GetValue() == 1.0;
-                                       },
-                                       [](const Exponent<Expression, Real>& oneCase) -> std::unique_ptr<Expression> {
-                                           return oneCase.GetMostSigOp().Copy();
-                                   })
-                                   .Case(
-                                       [](const Exponent<Real, Expression>& oneCase) -> bool {
-                                           const Real& base = oneCase.GetMostSigOp();
-                                           return base.GetValue() == 1.0;
-                                       },
-                                       [](const Exponent<Real, Expression>&) -> std::unique_ptr<Expression> {
-                                       return std::make_unique<Real>(1.0);
-                                   })
-                                   .Case(
-                                       [](const Exponent<Imaginary, Real>&) -> bool { return true; },
-                                       [](const Exponent<Imaginary, Real>& ImgCase) -> std::unique_ptr<Expression> {
-                                           switch (const auto power = std::fmod((ImgCase.GetLeastSigOp()).GetValue(), 4); static_cast<int>(power)) {
-                                       case 0:
-                                           return std::make_unique<Real>(1);
-                                       case 1:
-                                           return std::make_unique<Imaginary>();
-                                       case 2:
-                                           return std::make_unique<Real>(-1);
-                                       case 3:
-                                           return std::make_unique<Multiply<Real, Imaginary>>(Real{ -1 }, Imaginary{});
-                                       default:
-                                           return {};
-                                       }
-                                   })
-                                   .Case(
-                                       [](const Exponent<Multiply<Real, Expression>, Real>& ImgCase) -> bool {
-                                           return ImgCase.GetMostSigOp().GetMostSigOp().GetValue() < 0 && ImgCase.GetLeastSigOp().GetValue() == 0.5;
-                                       },
-                                       [](const Exponent<Multiply<Real, Expression>, Real>& ImgCase) -> std::unique_ptr<Expression> {
-                                           return std::make_unique<Multiply<>>(
-                                               Multiply{ Real{ pow(std::abs(ImgCase.GetMostSigOp().GetMostSigOp().GetValue()), 0.5) },
-                                                         Exponent{ ImgCase.GetMostSigOp().GetLeastSigOp(), Real{ 0.5 } } },
-                                               Imaginary{});
-                                   })
-                                   .Case(
-                                    [](const Exponent<Exponent<>, Expression>&) -> bool { return true; },
-                                   [](const Exponent<Exponent<>, Expression>& expExpCase) -> std::unique_ptr<Expression> {
-                                       return std::make_unique<Exponent<>>(expExpCase.GetMostSigOp().GetMostSigOp(),
-                                           *(Multiply{ expExpCase.GetMostSigOp().GetLeastSigOp(), expExpCase.GetLeastSigOp() }.Simplify()));
-                                   })
-                                   .Case(
-                                    [](const Exponent<Expression, Log<>>& logCase) -> bool {
-                                        return logCase.GetMostSigOp().Equals(logCase.GetLeastSigOp().GetMostSigOp());
-                                    },
-                                   [](const Exponent<Expression, Log<>>& logCase) -> std::unique_ptr<Expression> {
-                                        return logCase.GetLeastSigOp().GetLeastSigOp().Copy();
-                                   });
+                                 .Case(
+                                     [](const Exponent<Expression, Real>& zeroCase) -> bool {
+                                         // TODO: Optimize. We're calling RecursiveCast<Expression<Real, Expression> twice. Perhaps a map of expression types to a vector of lambdas?
+                                         const Real& power = zeroCase.GetLeastSigOp();
+                                         return power.GetValue() == 0.0;
+                                     },
+                                     [](const Exponent<Expression, Real>&) -> std::unique_ptr<Expression> {
+                                         return std::make_unique<Real>(1.0);
+                                     })
+                                 .Case(
+                                     [](const Exponent<Real, Expression>& zeroCase) -> bool {
+                                         const Real& base = zeroCase.GetMostSigOp();
+                                         return base.GetValue() == 0.0;
+                                     },
+                                     [](const Exponent<Real, Expression>&) -> std::unique_ptr<Expression> {
+                                         return std::make_unique<Real>(0.0);
+                                     })
+                                 .Case(
+                                     [](const Exponent<Real>&) { return true; },
+                                     [](const Exponent<Real>& realCase) -> std::unique_ptr<Expression> {
+                                         const Real& base = realCase.GetMostSigOp();
+                                         const Real& power = realCase.GetLeastSigOp();
+                                         return std::make_unique<Real>(pow(base.GetValue(), power.GetValue()));
+                                     })
+                                 .Case(
+                                     [](const Exponent<Expression, Real>& oneCase) -> bool {
+                                         const Real& power = oneCase.GetLeastSigOp();
+                                         return power.GetValue() == 1.0;
+                                     },
+                                     [](const Exponent<Expression, Real>& oneCase) -> std::unique_ptr<Expression> {
+                                         return oneCase.GetMostSigOp().Copy();
+                                     })
+                                 .Case(
+                                     [](const Exponent<Real, Expression>& oneCase) -> bool {
+                                         const Real& base = oneCase.GetMostSigOp();
+                                         return base.GetValue() == 1.0;
+                                     },
+                                     [](const Exponent<Real, Expression>&) -> std::unique_ptr<Expression> {
+                                         return std::make_unique<Real>(1.0);
+                                     })
+                                 .Case(
+                                     [](const Exponent<Imaginary, Real>&) -> bool { return true; },
+                                     [](const Exponent<Imaginary, Real>& ImgCase) -> std::unique_ptr<Expression> {
+                                         switch (const auto power = std::fmod((ImgCase.GetLeastSigOp()).GetValue(), 4); static_cast<int>(power)) {
+                                         case 0:
+                                             return std::make_unique<Real>(1);
+                                         case 1:
+                                             return std::make_unique<Imaginary>();
+                                         case 2:
+                                             return std::make_unique<Real>(-1);
+                                         case 3:
+                                             return std::make_unique<Multiply<Real, Imaginary>>(Real { -1 }, Imaginary {});
+                                         default:
+                                             return {};
+                                         }
+                                     })
+                                 .Case(
+                                     [](const Exponent<Multiply<Real, Expression>, Real>& ImgCase) -> bool {
+                                         return ImgCase.GetMostSigOp().GetMostSigOp().GetValue() < 0 && ImgCase.GetLeastSigOp().GetValue() == 0.5;
+                                     },
+                                     [](const Exponent<Multiply<Real, Expression>, Real>& ImgCase) -> std::unique_ptr<Expression> {
+                                         return std::make_unique<Multiply<>>(
+                                             Multiply { Real { pow(std::abs(ImgCase.GetMostSigOp().GetMostSigOp().GetValue()), 0.5) },
+                                                 Exponent { ImgCase.GetMostSigOp().GetLeastSigOp(), Real { 0.5 } } },
+                                             Imaginary {});
+                                     })
+                                 .Case(
+                                     [](const Exponent<Exponent<>, Expression>&) -> bool { return true; },
+                                     [](const Exponent<Exponent<>, Expression>& expExpCase) -> std::unique_ptr<Expression> {
+                                         return std::make_unique<Exponent<>>(expExpCase.GetMostSigOp().GetMostSigOp(),
+                                             *(Multiply { expExpCase.GetMostSigOp().GetLeastSigOp(), expExpCase.GetLeastSigOp() }.Simplify()));
+                                     })
+                                 .Case(
+                                     [](const Exponent<Expression, Log<>>& logCase) -> bool {
+                                         return logCase.GetMostSigOp().Equals(logCase.GetLeastSigOp().GetMostSigOp());
+                                     },
+                                     [](const Exponent<Expression, Log<>>& logCase) -> std::unique_ptr<Expression> {
+                                         return logCase.GetLeastSigOp().GetLeastSigOp().Copy();
+                                     });
 
     const auto simplifiedBase = mostSigOp->Simplify();
     const auto simplifiedPower = leastSigOp->Simplify();

--- a/src/Exponent.cpp
+++ b/src/Exponent.cpp
@@ -26,65 +26,87 @@ Exponent<Expression>::Exponent(const Expression& base, const Expression& power)
 auto Exponent<Expression>::Simplify() const -> std::unique_ptr<Expression>
 {
     static auto match_cast = MatchCast<Expression>()
-                                 .Case([](const Exponent<Expression, Real>& zeroCase) -> std::unique_ptr<Expression> {
-                                     if (const Real& power = zeroCase.GetLeastSigOp(); power.GetValue() == 0.0)
-                                         return std::make_unique<Real>(1.0);
-                                     return {};
-                                 })
-                                 .Case([](const Exponent<Real, Expression>& zeroCase) -> std::unique_ptr<Expression> {
-                                     if (const Real& base = zeroCase.GetMostSigOp(); base.GetValue() == 0.0)
-                                         return std::make_unique<Real>(0.0);
-                                     return {};
-                                 })
-                                 .Case([](const Exponent<Real>& realCase) -> std::unique_ptr<Expression> {
-                                     const Real& base = realCase.GetMostSigOp();
-                                     const Real& power = realCase.GetLeastSigOp();
-                                     return std::make_unique<Real>(pow(base.GetValue(), power.GetValue()));
-                                 })
-                                 .Case([](const Exponent<Expression, Real>& oneCase) -> std::unique_ptr<Expression> {
-                                     if (const Real& power = oneCase.GetLeastSigOp(); power.GetValue() == 1.0)
-                                         return oneCase.GetMostSigOp().Copy();
-                                     return {};
-                                 })
-                                 .Case([](const Exponent<Real, Expression>& oneCase) -> std::unique_ptr<Expression> {
-                                     if (const Real& base = oneCase.GetMostSigOp(); base.GetValue() == 1.0)
-                                         return std::make_unique<Real>(1.0);
-                                     return {};
-                                 })
-                                 .Case([](const Exponent<Imaginary, Real>& ImgCase) -> std::unique_ptr<Expression> {
-                                     const auto power = std::fmod((ImgCase.GetLeastSigOp()).GetValue(), 4);
-                                     switch (static_cast<int>(power)) {
-                                     case 0:
-                                         return std::make_unique<Real>(1);
-                                     case 1:
-                                         return std::make_unique<Imaginary>();
-                                     case 2:
-                                         return std::make_unique<Real>(-1);
-                                     case 3:
-                                         return std::make_unique<Multiply<Real, Imaginary>>(Real { -1 }, Imaginary {});
-                                     default:
-                                         return {};
-                                     }
-                                 })
-                                 .Case([](const Exponent<Multiply<Real, Expression>, Real>& ImgCase) -> std::unique_ptr<Expression> {
-                                     if (ImgCase.GetMostSigOp().GetMostSigOp().GetValue() < 0 && ImgCase.GetLeastSigOp().GetValue() == 0.5) {
-                                         return std::make_unique<Multiply<>>(
-                                             Multiply { Real { pow(std::abs(ImgCase.GetMostSigOp().GetMostSigOp().GetValue()), 0.5) },
-                                                 Exponent { ImgCase.GetMostSigOp().GetLeastSigOp(), Real { 0.5 } } },
-                                             Imaginary {});
-                                     }
-                                     return {};
-                                 })
-                                 .Case([](const Exponent<Exponent, Expression>& expExpCase) -> std::unique_ptr<Expression> {
-                                     return std::make_unique<Exponent>(expExpCase.GetMostSigOp().GetMostSigOp(),
-                                         *(Multiply { expExpCase.GetMostSigOp().GetLeastSigOp(), expExpCase.GetLeastSigOp() }.Simplify()));
-                                 })
-                                 .Case([](const Exponent<Expression, Log<>>& logCase) -> std::unique_ptr<Expression> {
-                                     if (logCase.GetMostSigOp().Equals(logCase.GetLeastSigOp().GetMostSigOp())) {
-                                         return logCase.GetLeastSigOp().GetLeastSigOp().Copy();
-                                     }
-                                     return {};
-                                 });
+                                   .Case(
+                                       [](const Exponent<Expression, Real>& zeroCase) -> bool {
+                                           // TODO: Optimize. We're calling RecursiveCast<Expression<Real, Expression> twice. Perhaps a map of expression types to a vector of lambdas?
+                                           const Real& power = zeroCase.GetLeastSigOp();
+                                           return power.GetValue() == 0.0;
+                                        },
+                                        [](const Exponent<Expression, Real>&) -> std::unique_ptr<Expression> {
+                                            return std::make_unique<Real>(1.0);
+                                        }
+                                   )
+                                   .Case(
+                                       [](const Exponent<Real, Expression>& zeroCase) -> bool {
+                                           const Real& base = zeroCase.GetMostSigOp();
+                                           return base.GetValue() == 0.0;
+                                        },
+                                        [](const Exponent<Real, Expression>&) -> std::unique_ptr<Expression> {
+                                            return std::make_unique<Real>(0.0);
+                                        }
+                                   )
+                                   .Case(
+                                       [](const Exponent<Real>&) { return true; },
+                                       [](const Exponent<Real>& realCase) -> std::unique_ptr<Expression> {
+                                       const Real& base = realCase.GetMostSigOp();
+                                       const Real& power = realCase.GetLeastSigOp();
+                                       return std::make_unique<Real>(pow(base.GetValue(), power.GetValue()));
+                                   })
+                                   .Case(
+                                       [](const Exponent<Expression, Real>& oneCase) -> bool {
+                                           const Real& power = oneCase.GetLeastSigOp();
+                                           return power.GetValue() == 1.0;
+                                       },
+                                       [](const Exponent<Expression, Real>& oneCase) -> std::unique_ptr<Expression> {
+                                           return oneCase.GetMostSigOp().Copy();
+                                   })
+                                   .Case(
+                                       [](const Exponent<Real, Expression>& oneCase) -> bool {
+                                           const Real& base = oneCase.GetMostSigOp();
+                                           return base.GetValue() == 1.0;
+                                       },
+                                       [](const Exponent<Real, Expression>&) -> std::unique_ptr<Expression> {
+                                       return std::make_unique<Real>(1.0);
+                                   })
+                                   .Case(
+                                       [](const Exponent<Imaginary, Real>&) -> bool { return true; },
+                                       [](const Exponent<Imaginary, Real>& ImgCase) -> std::unique_ptr<Expression> {
+                                           switch (const auto power = std::fmod((ImgCase.GetLeastSigOp()).GetValue(), 4); static_cast<int>(power)) {
+                                       case 0:
+                                           return std::make_unique<Real>(1);
+                                       case 1:
+                                           return std::make_unique<Imaginary>();
+                                       case 2:
+                                           return std::make_unique<Real>(-1);
+                                       case 3:
+                                           return std::make_unique<Multiply<Real, Imaginary>>(Real{ -1 }, Imaginary{});
+                                       default:
+                                           return {};
+                                       }
+                                   })
+                                   .Case(
+                                       [](const Exponent<Multiply<Real, Expression>, Real>& ImgCase) -> bool {
+                                           return ImgCase.GetMostSigOp().GetMostSigOp().GetValue() < 0 && ImgCase.GetLeastSigOp().GetValue() == 0.5;
+                                       },
+                                       [](const Exponent<Multiply<Real, Expression>, Real>& ImgCase) -> std::unique_ptr<Expression> {
+                                           return std::make_unique<Multiply<>>(
+                                               Multiply{ Real{ pow(std::abs(ImgCase.GetMostSigOp().GetMostSigOp().GetValue()), 0.5) },
+                                                         Exponent{ ImgCase.GetMostSigOp().GetLeastSigOp(), Real{ 0.5 } } },
+                                               Imaginary{});
+                                   })
+                                   .Case(
+                                    [](const Exponent<Exponent<>, Expression>&) -> bool { return true; },
+                                   [](const Exponent<Exponent<>, Expression>& expExpCase) -> std::unique_ptr<Expression> {
+                                       return std::make_unique<Exponent<>>(expExpCase.GetMostSigOp().GetMostSigOp(),
+                                           *(Multiply{ expExpCase.GetMostSigOp().GetLeastSigOp(), expExpCase.GetLeastSigOp() }.Simplify()));
+                                   })
+                                   .Case(
+                                    [](const Exponent<Expression, Log<>>& logCase) -> bool {
+                                        return logCase.GetMostSigOp().Equals(logCase.GetLeastSigOp().GetMostSigOp());
+                                    },
+                                   [](const Exponent<Expression, Log<>>& logCase) -> std::unique_ptr<Expression> {
+                                        return logCase.GetLeastSigOp().GetLeastSigOp().Copy();
+                                   });
 
     const auto simplifiedBase = mostSigOp->Simplify();
     const auto simplifiedPower = leastSigOp->Simplify();


### PR DESCRIPTION
### Description

This pull request introduces a series of improvements and updates:

- **`MatchCast` Refactoring**:
  - Splits the `Case` into separate check and transformer lambdas for improved readability and maintainability.
  - Adds stricter type compatibility validation between checks and transformers.

- **Boost Dependency Update**:
  - Replaces custom `lambda_traits` with `Boost's callable_traits` to improve reliability and code cleanliness.

- **`consteval` Implementation**:
  - Adds the `consteval` keyword to the `MatchCastImpl::Case` method, enforcing compile-time evaluation for safer, predictable code.

- **C++23 Standard Upgrade**:
  - Updates the project to target C++23.
  - Refactors error handling by replacing `std::variant` with `std::expected` in `FromString`.

- **Boost Any Replacement**:
  - Substitutes `std::any` with `boost::any` across the codebase for enhanced type safety and performance.

### Checklist

- [x] Code has been tested locally
- [ ] Related documentation has been updated
- [ ] No new warnings have been introduced