### PR TITLE
[Feature] Command Line Interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,10 @@ option(OASIS_BUILD_WITH_COVERAGE
 option(OASIS_BUILD_PARANOID
        "Enables the -Werror flag friends when building Oasis" OFF)
 
+if (OASIS_BUILD_CLI)
+    set(OASIS_BUILD_IO ON CACHE BOOL "OASIS_BUILD_IO enabled by OASIS_BUILD_CLI" FORCE)
+endif ()
+
 # Adds compiler flags for code coverage. Note that only the Clang compiler is
 # currently supported for code coverage.
 if(OASIS_BUILD_WITH_COVERAGE)
@@ -34,13 +38,14 @@ FetchContent_MakeAvailable(Catch2)
 
 include(cmake/FetchBoost.cmake)
 include(cmake/FetchEigen.cmake)
-include(cmake/FetchTinyxml2.cmake)
 
 # Processes the CMakeLists.txt for each target.
 add_subdirectory(include)
 add_subdirectory(src)
 
 if(OASIS_BUILD_IO)
+    include(cmake/FetchTinyxml2.cmake)
+
     FetchContent_Declare(
         GSL
         GIT_REPOSITORY "https://github.com/microsoft/GSL"
@@ -55,3 +60,16 @@ endif()
 if(OASIS_BUILD_TESTS)
     add_subdirectory(tests)
 endif()
+
+if (OASIS_BUILD_CLI)
+    include(cmake/FetchLinenoise.cmake)
+
+    FetchContent_Declare(
+            fmt
+            GIT_REPOSITORY https://github.com/fmtlib/fmt
+            GIT_TAG        11.1.3)
+
+    FetchContent_MakeAvailable(fmt)
+
+    add_subdirectory(cli)
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,11 @@ option(OASIS_BUILD_WITH_COVERAGE
 option(OASIS_BUILD_PARANOID
        "Enables the -Werror flag friends when building Oasis" OFF)
 
-if (OASIS_BUILD_CLI)
-    set(OASIS_BUILD_IO ON CACHE BOOL "OASIS_BUILD_IO enabled by OASIS_BUILD_CLI" FORCE)
-endif ()
+if(OASIS_BUILD_CLI)
+    set(OASIS_BUILD_IO
+        ON
+        CACHE BOOL "OASIS_BUILD_IO enabled by OASIS_BUILD_CLI" FORCE)
+endif()
 
 # Adds compiler flags for code coverage. Note that only the Clang compiler is
 # currently supported for code coverage.
@@ -61,15 +63,15 @@ if(OASIS_BUILD_TESTS)
     add_subdirectory(tests)
 endif()
 
-if (OASIS_BUILD_CLI)
+if(OASIS_BUILD_CLI)
     include(cmake/FetchLinenoise.cmake)
 
     FetchContent_Declare(
-            fmt
-            GIT_REPOSITORY https://github.com/fmtlib/fmt
-            GIT_TAG        11.1.3)
+        fmt
+        GIT_REPOSITORY https://github.com/fmtlib/fmt
+        GIT_TAG 11.1.3)
 
     FetchContent_MakeAvailable(fmt)
 
     add_subdirectory(cli)
-endif ()
+endif()

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(OasisCLI main.cpp)
+target_link_libraries(OasisCLI PRIVATE Oasis::Oasis Oasis::IO Linenoise fmt::fmt)
+target_compile_features(OasisCLI PRIVATE cxx_std_23)

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_executable(OasisCLI main.cpp)
-target_link_libraries(OasisCLI PRIVATE Oasis::Oasis Oasis::IO Linenoise fmt::fmt)
+target_link_libraries(OasisCLI PRIVATE Oasis::Oasis Oasis::IO Linenoise
+                                       fmt::fmt)
 target_compile_features(OasisCLI PRIVATE cxx_std_23)

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -23,7 +23,8 @@ int main(int argc, char** argv)
     linenoiseHistorySetMaxLen(16);
 
     Oasis::InFixSerializer serializer;
-    auto err_style = fg(fmt::color::indian_red);
+    constexpr auto err_style = fg(fmt::color::indian_red);
+    constexpr auto success_style = fg(fmt::color::green);
 
     const char* line;
     while ((line = linenoise("> ")) != nullptr) {
@@ -43,9 +44,7 @@ int main(int argc, char** argv)
                 return expr->Accept(serializer);
             });
 
-        if (result.has_value()) fmt::println("  {}", result.value());
-        else fmt::println("  {}", styled(result.error(), err_style));
-
+        fmt::println("  {}", fmt::styled(result.value_or(result.error()), result.has_value() ? success_style : err_style));
         std::fflush(stdout);
     }
 

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -1,0 +1,50 @@
+//
+// Created by Matthew McCall on 2/19/25.
+//
+
+#include <cstdlib>
+#include <cstdio>
+
+#include "Oasis/FromString.hpp"
+#include "Oasis/InFixSerializer.hpp"
+
+#include <fmt/color.h>
+#include <linenoise.h>
+
+int main(int argc, char **argv) {
+    std::setvbuf(stdout, nullptr, _IONBF, 0);
+    linenoiseHistorySetMaxLen(16);
+
+    Oasis::InFixSerializer serializer;
+
+    const char *line;
+    while((line = linenoise("> ")) != nullptr) {
+        std::string input { line };
+
+        linenoiseHistoryAdd(line);
+        delete[] line;
+
+        auto parseResult = Oasis::FromInFix(Oasis::PreProcessInFix(input));
+        auto err_style = fg(fmt::color::red);
+        if (!parseResult.Ok()) {
+            print(err_style, "< Failed to parse: {}\n", parseResult.GetErrorMessage());
+            continue;
+        }
+
+        auto simplifyResult = parseResult.GetResult().Simplify();
+        if (!simplifyResult) {
+            print(err_style, "< Failed to simplify\n");
+            continue;
+        }
+
+        auto serializeResult = simplifyResult->Accept(serializer);
+        if (!serializeResult) {
+            print(err_style, "< Failed to serialize\n");
+            continue;
+        }
+
+        fmt::println("< {}", serializeResult.value());
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -25,12 +25,12 @@ int main(int argc, char **argv) {
 
         auto parseResult = Oasis::FromInFix(Oasis::PreProcessInFix(input));
         auto err_style = fg(fmt::color::indian_red);
-        if (!parseResult.Ok()) {
-            print(err_style, "  Failed to parse: {}\n", parseResult.GetErrorMessage());
+        if (!parseResult) {
+            print(err_style, "  Failed to parse: {}\n", parseResult.error());
             continue;
         }
 
-        auto simplifyResult = parseResult.GetResult().Simplify();
+        const auto simplifyResult = parseResult.value()->Simplify();
         if (!simplifyResult) {
             print(err_style, "  Failed to simplify\n");
             continue;
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
 
         auto serializeResult = simplifyResult->Accept(serializer);
         if (!serializeResult) {
-            print(err_style, "  Failed to serialize\n");
+            print(err_style, "  Failed to serialize: {}\n", serializeResult.error());
             continue;
         }
 

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -8,40 +8,45 @@
 #include "Oasis/FromString.hpp"
 #include "Oasis/InFixSerializer.hpp"
 
+#include <boost/callable_traits/return_type.hpp>
 #include <fmt/color.h>
 #include <linenoise.h>
 
-int main(int argc, char **argv) {
-    std::setvbuf(stdout, nullptr, _IONBF, 0);
+template <typename FnT>
+auto operator|(const std::string& str, FnT fn) -> boost::callable_traits::return_type_t<FnT>
+{
+    return fn(str);
+}
+
+int main(int argc, char** argv)
+{
     linenoiseHistorySetMaxLen(16);
 
     Oasis::InFixSerializer serializer;
+    auto err_style = fg(fmt::color::indian_red);
 
-    const char *line;
-    while((line = linenoise("> ")) != nullptr) {
-        std::string input { line };
+    const char* line;
+    while ((line = linenoise("> ")) != nullptr) {
+        std::string input{ line };
         delete[] line;
-
-        if (input.empty()) {
-            continue;
-        }
+        if (input.empty())  continue;
 
         linenoiseHistoryAdd(input.c_str());
 
-        auto parseResult = Oasis::FromInFix(Oasis::PreProcessInFix(input));
+        // Calling Oasis::FromInFix passed as template fails because defaulted parameters aren't represented in the type, so a wrapper is needed
+        auto Parse = [](const std::string& in) { return Oasis::FromInFix(in); };
+        auto result = (input | Oasis::PreProcessInFix | Parse)
+            .transform([](const std::unique_ptr<Oasis::Expression>& expr) -> std::unique_ptr<Oasis::Expression> {
+                return expr->Simplify();
+            })
+            .and_then([&serializer](const std::unique_ptr<Oasis::Expression>& expr) -> std::expected<std::string, std::string> {
+                return expr->Accept(serializer);
+            });
 
-        Oasis::FromInFix(Oasis::PreProcessInFix(input))
-        .and_then([&serializer](const std::unique_ptr<Oasis::Expression>& expr) -> std::expected<std::string, std::string> {
-            return expr->Accept(serializer);
-        })
-        .transform([&](const std::string& str) -> void {
-            fmt::println("  {}", str);
-        })
-        .transform_error([&](const std::string& err) -> std::string {
-            static auto err_style = fg(fmt::color::indian_red);
-            print(err_style, "  {}\n", err);
-            return err;
-        });
+        if (result.has_value()) fmt::println("  {}", result.value());
+        else fmt::println("  {}", styled(result.error(), err_style));
+
+        std::fflush(stdout);
     }
 
     return EXIT_SUCCESS;

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -12,7 +12,6 @@
 #include <linenoise.h>
 
 int main(int argc, char **argv) {
-    std::setvbuf(stdout, nullptr, _IONBF, 0);
     linenoiseHistorySetMaxLen(16);
 
     Oasis::InFixSerializer serializer;
@@ -20,30 +19,30 @@ int main(int argc, char **argv) {
     const char *line;
     while((line = linenoise("> ")) != nullptr) {
         std::string input { line };
-
-        linenoiseHistoryAdd(line);
         delete[] line;
 
+        linenoiseHistoryAdd(input.c_str());
+
         auto parseResult = Oasis::FromInFix(Oasis::PreProcessInFix(input));
-        auto err_style = fg(fmt::color::red);
+        auto err_style = fg(fmt::color::indian_red);
         if (!parseResult.Ok()) {
-            print(err_style, "< Failed to parse: {}\n", parseResult.GetErrorMessage());
+            print(err_style, "  Failed to parse: {}\n", parseResult.GetErrorMessage());
             continue;
         }
 
         auto simplifyResult = parseResult.GetResult().Simplify();
         if (!simplifyResult) {
-            print(err_style, "< Failed to simplify\n");
+            print(err_style, "  Failed to simplify\n");
             continue;
         }
 
         auto serializeResult = simplifyResult->Accept(serializer);
         if (!serializeResult) {
-            print(err_style, "< Failed to serialize\n");
+            print(err_style, "  Failed to serialize\n");
             continue;
         }
 
-        fmt::println("< {}", serializeResult.value());
+        fmt::println("  {}", serializeResult.value());
     }
 
     return EXIT_SUCCESS;

--- a/cmake/FetchLinenoise.cmake
+++ b/cmake/FetchLinenoise.cmake
@@ -1,0 +1,12 @@
+FetchContent_Declare(
+        Linenoise
+        GIT_REPOSITORY https://github.com/antirez/linenoise.git
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        INSTALL_COMMAND ""
+)
+
+FetchContent_MakeAvailable(Linenoise)
+
+add_library(Linenoise ${linenoise_SOURCE_DIR}/linenoise.c)
+target_include_directories(Linenoise PUBLIC ${linenoise_SOURCE_DIR})

--- a/include/Oasis/Concepts.hpp
+++ b/include/Oasis/Concepts.hpp
@@ -66,9 +66,9 @@ concept IVisitor = requires {
 };
 
 template <typename T>
-concept ExpectedWithStringView = requires {
+concept ExpectedWithString = requires {
     typename T::unexpected_type;
-    requires std::same_as<typename T::unexpected_type, std::unexpected<std::string_view>>;
+    requires std::same_as<typename T::unexpected_type, std::unexpected<std::string>>;
 };
 
 }

--- a/include/Oasis/Expression.hpp
+++ b/include/Oasis/Expression.hpp
@@ -181,7 +181,7 @@ public:
     auto Accept(T& visitor) const -> std::expected<typename T::RetT, std::string_view>;
 
     template <IVisitor T>
-        requires ExpectedWithStringView<typename T::RetT>
+        requires ExpectedWithString<typename T::RetT>
     auto Accept(T& visitor) const -> typename T::RetT;
 
     virtual ~Expression() = default;
@@ -206,7 +206,7 @@ auto Expression::Accept(T& visitor) const -> std::expected<typename T::RetT, std
 }
 
 template <IVisitor T>
-    requires ExpectedWithStringView<typename T::RetT>
+    requires ExpectedWithString<typename T::RetT>
 auto Expression::Accept(T& visitor) const -> typename T::RetT
 {
     try {

--- a/io/include/Oasis/FromString.hpp
+++ b/io/include/Oasis/FromString.hpp
@@ -19,7 +19,8 @@ enum class ParseImaginaryOption {
 
 auto PreProcessInFix(const std::string& str) -> std::string;
 
-auto FromInFix(const std::string& str, ParseImaginaryOption option = ParseImaginaryOption::UseI) -> std::expected<std::unique_ptr<Expression>, std::string>;
+using FromInFixResult = std::expected<std::unique_ptr<Expression>, std::string>;
+auto FromInFix(const std::string& str, ParseImaginaryOption option = ParseImaginaryOption::UseI) -> FromInFixResult;
 
 }
 

--- a/io/include/Oasis/InFixSerializer.hpp
+++ b/io/include/Oasis/InFixSerializer.hpp
@@ -12,7 +12,7 @@
 
 namespace Oasis {
 
-class InFixSerializer final : public TypedVisitor<std::expected<std::string, std::string_view>> {
+class InFixSerializer final : public TypedVisitor<std::expected<std::string, std::string>> {
 public:
     auto TypedVisit(const Real& real) -> RetT override;
     auto TypedVisit(const Imaginary& imaginary) -> RetT override;
@@ -33,12 +33,12 @@ public:
     auto TypedVisit(const Magnitude<Expression>& magnitude) -> RetT override;
 
 private:
-    auto GetOpsOfBinExp(const DerivedFromBinaryExpression auto& visited) -> std::expected<std::pair<std::string, std::string>, std::string_view>;
-    auto SerializeArithBinExp(const DerivedFromBinaryExpression auto& visited, const std::string& op) -> std::expected<std::string, std::string_view>;
-    auto SerializeFuncBinExp(const DerivedFromBinaryExpression auto& visited, const std::string& func) -> std::expected<std::string, std::string_view>;
+    auto GetOpsOfBinExp(const DerivedFromBinaryExpression auto& visited) -> std::expected<std::pair<std::string, std::string>, std::string>;
+    auto SerializeArithBinExp(const DerivedFromBinaryExpression auto& visited, const std::string& op) -> std::expected<std::string, std::string>;
+    auto SerializeFuncBinExp(const DerivedFromBinaryExpression auto& visited, const std::string& func) -> std::expected<std::string, std::string>;
 };
 
-auto InFixSerializer::GetOpsOfBinExp(const DerivedFromBinaryExpression auto& visited) -> std::expected<std::pair<std::string, std::string>, std::string_view>
+auto InFixSerializer::GetOpsOfBinExp(const DerivedFromBinaryExpression auto& visited) -> std::expected<std::pair<std::string, std::string>, std::string>
 {
     InFixSerializer& thisSerializer = *this;
     return visited.GetMostSigOp().Accept(thisSerializer).and_then([&thisSerializer, &visited](const std::string& mostSigOpStr) {
@@ -48,14 +48,14 @@ auto InFixSerializer::GetOpsOfBinExp(const DerivedFromBinaryExpression auto& vis
     });
 }
 
-auto InFixSerializer::SerializeArithBinExp(const DerivedFromBinaryExpression auto& visited, const std::string& op) -> std::expected<std::string, std::string_view>
+auto InFixSerializer::SerializeArithBinExp(const DerivedFromBinaryExpression auto& visited, const std::string& op) -> RetT
 {
     return GetOpsOfBinExp(visited).transform([&op](const auto& ops) {
         return std::format("({}{}{})", ops.first, op, ops.second);
     });
 }
 
-auto InFixSerializer::SerializeFuncBinExp(const DerivedFromBinaryExpression auto& visited, const std::string& func) -> std::expected<std::string, std::string_view>
+auto InFixSerializer::SerializeFuncBinExp(const DerivedFromBinaryExpression auto& visited, const std::string& func) -> RetT
 {
     return GetOpsOfBinExp(visited).transform([&func](const auto& ops) {
         return std::format("{}({},{})", func, ops.first, ops.second);

--- a/io/include/Oasis/MathMLSerializer.hpp
+++ b/io/include/Oasis/MathMLSerializer.hpp
@@ -14,7 +14,7 @@
 
 namespace Oasis {
 
-class MathMLSerializer final : public TypedVisitor<std::expected<gsl::not_null<tinyxml2::XMLElement*>, std::string_view>> {
+class MathMLSerializer final : public TypedVisitor<std::expected<gsl::not_null<tinyxml2::XMLElement*>, std::string>> {
 public:
     explicit MathMLSerializer(tinyxml2::XMLDocument& doc);
 
@@ -39,11 +39,11 @@ public:
     [[nodiscard]] tinyxml2::XMLDocument& GetDocument() const;
 
 private:
-    auto GetOpsAsMathMLPair(const DerivedFromBinaryExpression auto& binexp) -> std::expected<std::pair<gsl::not_null<tinyxml2::XMLElement*>, gsl::not_null<tinyxml2::XMLElement*>>, std::string_view>;
+    auto GetOpsAsMathMLPair(const DerivedFromBinaryExpression auto& binexp) -> std::expected<std::pair<gsl::not_null<tinyxml2::XMLElement*>, gsl::not_null<tinyxml2::XMLElement*>>, std::string>;
     tinyxml2::XMLDocument& doc;
 };
 
-auto MathMLSerializer::GetOpsAsMathMLPair(const DerivedFromBinaryExpression auto& binexp) -> std::expected<std::pair<gsl::not_null<tinyxml2::XMLElement*>, gsl::not_null<tinyxml2::XMLElement*>>, std::string_view>
+auto MathMLSerializer::GetOpsAsMathMLPair(const DerivedFromBinaryExpression auto& binexp) -> std::expected<std::pair<gsl::not_null<tinyxml2::XMLElement*>, gsl::not_null<tinyxml2::XMLElement*>>, std::string>
 {
     MathMLSerializer& thisSerializer = *this;
     return binexp.GetMostSigOp().Accept(thisSerializer).and_then([&binexp, &thisSerializer](gsl::not_null<tinyxml2::XMLElement*> mostSigOp) {

--- a/io/include/Oasis/TeXSerializer.hpp
+++ b/io/include/Oasis/TeXSerializer.hpp
@@ -47,7 +47,7 @@ struct TeXOpts {
     std::set<Pkgs> packages = { Pkgs::ESDIFF };
 };
 
-class TeXSerializer final : public TypedVisitor<std::expected<std::string, std::string_view>> {
+class TeXSerializer final : public TypedVisitor<std::expected<std::string, std::string>> {
 public:
     TeXSerializer()
         : TeXSerializer(TeXOpts {})
@@ -94,11 +94,11 @@ public:
 private:
     TeXOpts latexOptions {};
 
-    auto GetOpsOfBinExp(const DerivedFromBinaryExpression auto& visited) -> std::expected<std::pair<std::string, std::string>, std::string_view>;
-    auto SerializeArithBinExp(const DerivedFromBinaryExpression auto& visited, const std::string& op) -> std::expected<std::string, std::string_view>;
+    auto GetOpsOfBinExp(const DerivedFromBinaryExpression auto& visited) -> std::expected<std::pair<std::string, std::string>, std::string>;
+    auto SerializeArithBinExp(const DerivedFromBinaryExpression auto& visited, const std::string& op) -> std::expected<std::string, std::string>;
 };
 
-auto TeXSerializer::GetOpsOfBinExp(const DerivedFromBinaryExpression auto& visited) -> std::expected<std::pair<std::string, std::string>, std::string_view>
+auto TeXSerializer::GetOpsOfBinExp(const DerivedFromBinaryExpression auto& visited) -> std::expected<std::pair<std::string, std::string>, std::string>
 {
     TeXSerializer& thisSerializer = *this;
     return visited.GetMostSigOp().Accept(thisSerializer).and_then([&thisSerializer, &visited](const std::string& mostSigOpStr) {
@@ -108,9 +108,9 @@ auto TeXSerializer::GetOpsOfBinExp(const DerivedFromBinaryExpression auto& visit
     });
 }
 
-auto TeXSerializer::SerializeArithBinExp(const DerivedFromBinaryExpression auto& visited, const std::string& op) -> std::expected<std::string, std::string_view>
+auto TeXSerializer::SerializeArithBinExp(const DerivedFromBinaryExpression auto& visited, const std::string& op) -> std::expected<std::string, std::string>
 {
-    return GetOpsOfBinExp(visited).and_then([&op, this](const std::pair<std::string, std::string>& ops) -> std::expected<std::string, std::string_view> {
+    return GetOpsOfBinExp(visited).and_then([&op, this](const std::pair<std::string, std::string>& ops) -> std::expected<std::string, std::string> {
         const auto& [mostSigOpStr, leastSigOpStr] = ops;
         if (latexOptions.spacing == TeXOpts::Spacing::MINIMAL)
             return std::format("\\left({}{}{}\\right)", mostSigOpStr, op, leastSigOpStr);

--- a/io/src/FromString.cpp
+++ b/io/src/FromString.cpp
@@ -184,16 +184,22 @@ auto SpaceAroundOperators(const std::string& str) -> std::string
 auto ImplicitMultiplication(const std::string& str) -> std::string
 {
     std::stringstream secondPassResult, sstr { str };
-    std::string token;
+    std::string lastToken = "", token;
 
     while (sstr >> token) {
-        std::string updatedToken;
-
-        if (is_function(token)) {
-            updatedToken = token;
-            secondPassResult << updatedToken;
+        if (is_function(token) || is_operator(token)) {
+            secondPassResult << token;
+            lastToken = token;
             continue;
         }
+
+        if (lastToken == ")" && token == "(") {
+            secondPassResult << '*' << token;
+            lastToken = token;
+            continue;
+        }
+
+        std::string updatedToken;
 
         for (size_t i = 0; i < token.size(); i++) {
             updatedToken += token[i];
@@ -212,13 +218,10 @@ auto ImplicitMultiplication(const std::string& str) -> std::string
             if (is_letter && is_letter_next) {
                 updatedToken += "*";
             }
-
-            if (token[i] == ')' && token[i + 1] == '(') {
-                updatedToken += "*";
-            }
         }
 
         secondPassResult << updatedToken;
+        lastToken = token;
     }
 
     return secondPassResult.str();

--- a/io/src/FromString.cpp
+++ b/io/src/FromString.cpp
@@ -261,15 +261,15 @@ auto FromInFix(const std::string& str, ParseImaginaryOption option) -> std::expe
     std::stack<std::unique_ptr<Expression>> st;
     std::stack<std::variant<Operator, Function, OpenParens>> ops;
 
-    std::string token, function_token;
-    std::stringstream ss(str);
+    std::string token;
+    std::stringstream ss{ str };
 
     while (ss >> token) {
         // Operand
         if (auto newNumber = is_number(token); newNumber) {
             st.push(std::make_unique<Real>(newNumber.value()));
-        } else if (auto func = is_function(token); func) {
-            ops.emplace(func.value());
+        } else if (auto newFunc = is_function(token); newFunc) {
+            ops.emplace(newFunc.value());
         }
         // Operator
         else if (auto newOp = is_operator(token); newOp) {

--- a/io/src/FromString.cpp
+++ b/io/src/FromString.cpp
@@ -38,11 +38,12 @@ enum class Function {
     Integral,
 };
 
-struct OpenParens {};
+struct OpenParens { };
 
 int prec(std::variant<Operator, Function, OpenParens> c)
 {
-    if (!std::holds_alternative<Operator>(c)) return -1;
+    if (!std::holds_alternative<Operator>(c))
+        return -1;
     auto op = std::get<Operator>(c);
 
     if (op == Operator::Exponent)
@@ -68,28 +69,29 @@ auto processOp(std::stack<std::variant<Operator, Function, OpenParens>>& ops, st
     st.pop();
 
     const auto topOp = ops.top();
-    if (!std::holds_alternative<Operator>(topOp)) return std::unexpected { "Invalid operator" };
+    if (!std::holds_alternative<Operator>(topOp))
+        return std::unexpected { "Invalid operator" };
     const auto op = std::get<Operator>(topOp);
     std::unique_ptr<Oasis::Expression> opExp;
 
     switch (op) {
     case Operator::Add:
-        opExp = Oasis::Add{ *left, *right }.Copy();
+        opExp = Oasis::Add { *left, *right }.Copy();
         break;
     case Operator::Subtract:
-        opExp = Oasis::Subtract{ *left, *right }.Copy();
+        opExp = Oasis::Subtract { *left, *right }.Copy();
         break;
     case Operator::Multiply:
-        opExp = Oasis::Multiply{ *left, *right }.Copy();
+        opExp = Oasis::Multiply { *left, *right }.Copy();
         break;
     case Operator::Divide:
-        opExp = Oasis::Divide{ *left, *right }.Copy();
+        opExp = Oasis::Divide { *left, *right }.Copy();
         break;
     case Operator::Exponent:
-        opExp = Oasis::Exponent{ *left, *right }.Copy();
+        opExp = Oasis::Exponent { *left, *right }.Copy();
         break;
     default:
-        return std::unexpected{ "Invalid operator" };
+        return std::unexpected { "Invalid operator" };
     }
 
     ops.pop();
@@ -108,28 +110,39 @@ auto processFunction(std::stack<std::unique_ptr<Oasis::Expression>>& st, const F
     const auto first_operand = std::move(st.top());
     st.pop();
 
-    if (function_token == Function::Log) return Oasis::Log { *first_operand, *second_operand }.Copy();
-    if (function_token == Function::Derivative) return Oasis::Derivative{ *first_operand, *second_operand }.Copy();
-    if (function_token == Function::Integral) return Oasis::Integral { *first_operand, *second_operand }.Copy();
-    
+    if (function_token == Function::Log)
+        return Oasis::Log { *first_operand, *second_operand }.Copy();
+    if (function_token == Function::Derivative)
+        return Oasis::Derivative { *first_operand, *second_operand }.Copy();
+    if (function_token == Function::Integral)
+        return Oasis::Integral { *first_operand, *second_operand }.Copy();
+
     return std::unexpected { "Invalid function" };
 }
 
 auto is_operator(const std::string& token) -> std::optional<Operator>
 {
-    if (token == "+") return Operator::Add;
-    if (token == "-") return Operator::Subtract;
-    if (token == "*") return Operator::Multiply;
-    if (token == "/") return Operator::Divide;
-    if (token == "^") return Operator::Exponent;
+    if (token == "+")
+        return Operator::Add;
+    if (token == "-")
+        return Operator::Subtract;
+    if (token == "*")
+        return Operator::Multiply;
+    if (token == "/")
+        return Operator::Divide;
+    if (token == "^")
+        return Operator::Exponent;
     return {};
 }
 
 auto is_function(const std::string& token) -> std::optional<Function>
 {
-    if (token == "log") return Function::Log;
-    if (token == "dd") return Function::Derivative;
-    if (token == "in") return Function::Integral;
+    if (token == "log")
+        return Function::Log;
+    if (token == "dd")
+        return Function::Derivative;
+    if (token == "in")
+        return Function::Integral;
     return {};
 }
 
@@ -211,7 +224,9 @@ auto ImplicitMultiplication(std::stringstream&& sstr) -> std::string
         for (size_t i = 0; i < token.size(); i++) {
             updatedToken += token[i];
 
-            if (i >= token.size() - 1) { continue; }
+            if (i >= token.size() - 1) {
+                continue;
+            }
 
             bool is_digit = isdigit(token[i]);
             bool is_letter = isalpha(token[i]);
@@ -257,8 +272,7 @@ auto FromInFix(const std::string& str, ParseImaginaryOption option) -> std::expe
         // '(' or function
         else if (token == "(") {
             ops.emplace(OpenParens());
-        }
-        else if (auto func = is_function(token); func) {
+        } else if (auto func = is_function(token); func) {
             ops.emplace(func.value());
         }
         // ','
@@ -267,7 +281,8 @@ auto FromInFix(const std::string& str, ParseImaginaryOption option) -> std::expe
             // function_active = true;
             while (!ops.empty() && !std::holds_alternative<OpenParens>(topOp)) {
                 auto processOpResult = processOp(ops, st);
-                if (!processOpResult) return std::unexpected { processOpResult.error() };
+                if (!processOpResult)
+                    return std::unexpected { processOpResult.error() };
                 st.emplace(std::move(processOpResult.value()));
             }
         }
@@ -276,7 +291,8 @@ auto FromInFix(const std::string& str, ParseImaginaryOption option) -> std::expe
             auto topOp = ops.top();
             while (!ops.empty() && !std::holds_alternative<OpenParens>(topOp)) {
                 auto processOpResult = processOp(ops, st);
-                if (!processOpResult) return std::unexpected { processOpResult.error() };
+                if (!processOpResult)
+                    return std::unexpected { processOpResult.error() };
                 st.emplace(std::move(processOpResult.value()));
             }
 
@@ -291,7 +307,8 @@ auto FromInFix(const std::string& str, ParseImaginaryOption option) -> std::expe
                 auto func = std::get<Function>(topOp);
                 ops.pop();
                 auto processFunctionResult = processFunction(st, func);
-                if (!processFunctionResult) return std::unexpected { processFunctionResult.error() };
+                if (!processFunctionResult)
+                    return std::unexpected { processFunctionResult.error() };
                 st.emplace(std::move(processFunctionResult.value()));
             }
         }
@@ -299,7 +316,8 @@ auto FromInFix(const std::string& str, ParseImaginaryOption option) -> std::expe
         else if (auto newOp = is_operator(token); newOp) {
             while (!ops.empty() && prec(ops.top()) >= prec(newOp.value())) {
                 auto processOpResult = processOp(ops, st);
-                if (!processOpResult) return std::unexpected { processOpResult.error() };
+                if (!processOpResult)
+                    return std::unexpected { processOpResult.error() };
                 st.emplace(std::move(processOpResult.value()));
             }
             ops.emplace(newOp.value());
@@ -311,11 +329,13 @@ auto FromInFix(const std::string& str, ParseImaginaryOption option) -> std::expe
     // Process remaining ops
     while (!ops.empty()) {
         auto processOpResult = processOp(ops, st);
-        if (!processOpResult) return std::unexpected { processOpResult.error() };
+        if (!processOpResult)
+            return std::unexpected { processOpResult.error() };
         st.emplace(std::move(processOpResult.value()));
     }
 
-    if (st.empty()) return std::unexpected { "Parsing failed" };
+    if (st.empty())
+        return std::unexpected { "Parsing failed" };
     return st.top()->Copy(); // root of the expression tree
 }
 

--- a/io/src/FromString.cpp
+++ b/io/src/FromString.cpp
@@ -285,9 +285,8 @@ auto FromInFix(const std::string& str, ParseImaginaryOption option) -> std::expe
         }
         // ','
         else if (token == ",") {
-            auto topOp = ops.top();
             // function_active = true;
-            while (!ops.empty() && !std::holds_alternative<OpenParens>(topOp)) {
+            while (!ops.empty() && !std::holds_alternative<OpenParens>(ops.top())) {
                 auto processOpResult = processOp(ops, st);
                 if (!processOpResult)
                     return std::unexpected { processOpResult.error() };
@@ -296,22 +295,19 @@ auto FromInFix(const std::string& str, ParseImaginaryOption option) -> std::expe
         }
         // ')'
         else if (token == ")") {
-            auto topOp = ops.top();
-            while (!ops.empty() && !std::holds_alternative<OpenParens>(topOp)) {
+            while (!ops.empty() && !std::holds_alternative<OpenParens>(ops.top())) {
                 auto processOpResult = processOp(ops, st);
                 if (!processOpResult)
                     return std::unexpected { processOpResult.error() };
                 st.emplace(std::move(processOpResult.value()));
             }
 
-            topOp = ops.top();
-            if (ops.empty() || !std::holds_alternative<OpenParens>(topOp)) {
+            if (auto topOp = ops.top(); ops.empty() || !std::holds_alternative<OpenParens>(topOp)) {
                 return std::unexpected { "Mismatched parenthesis" };
             }
 
             ops.pop(); // pop '('
-            topOp = ops.top();
-            if (!ops.empty() && std::holds_alternative<Function>(topOp)) {
+            if (auto topOp = ops.top(); !ops.empty() && std::holds_alternative<Function>(topOp)) {
                 auto func = std::get<Function>(topOp);
                 ops.pop();
                 auto processFunctionResult = processFunction(st, func);

--- a/io/src/FromString.cpp
+++ b/io/src/FromString.cpp
@@ -160,14 +160,19 @@ std::unique_ptr<Oasis::Expression> ParseOperand(const std::string& token, const 
 
 }
 
-auto operator|(const std::string& input, const std::function<std::string(const std::string&)>& func) -> std::string
+auto operator|(const std::string& input, const std::function<std::stringstream(const std::string&)>& func) -> std::stringstream
 {
     return func(input);
 }
 
+auto operator|(std::stringstream&& input, const std::function<std::string(std::stringstream&&)>& func) -> std::string
+{
+    return func(std::move(input));
+}
+
 namespace Oasis {
 
-auto SpaceAroundOperators(const std::string& str) -> std::string
+auto SpaceAroundOperators(const std::string& str) -> std::stringstream
 {
     std::stringstream result;
     std::string operators = "+-*/^(),";
@@ -180,12 +185,12 @@ auto SpaceAroundOperators(const std::string& str) -> std::string
         }
     }
 
-    return result.str();
+    return result;
 }
 
-auto ImplicitMultiplication(const std::string& str) -> std::string
+auto ImplicitMultiplication(std::stringstream&& sstr) -> std::string
 {
-    std::stringstream secondPassResult, sstr { str };
+    std::stringstream secondPassResult;
     std::string lastToken, token;
 
     while (sstr >> token) {
@@ -231,7 +236,7 @@ auto ImplicitMultiplication(const std::string& str) -> std::string
 
 auto PreProcessInFix(const std::string& str) -> std::string
 {
-    return str | SpaceAroundOperators | ImplicitMultiplication | SpaceAroundOperators;
+    return (str | SpaceAroundOperators | ImplicitMultiplication | SpaceAroundOperators).str();
 }
 
 auto FromInFix(const std::string& str, ParseImaginaryOption option) -> std::expected<std::unique_ptr<Expression>, std::string>

--- a/io/src/FromString.cpp
+++ b/io/src/FromString.cpp
@@ -34,17 +34,6 @@ int prec(const char c)
     return -1;
 }
 
-template <typename T>
-void setOps(T& exp, const std::unique_ptr<Oasis::Expression>& op1, const std::unique_ptr<Oasis::Expression>& op2)
-{
-    if (op1) {
-        exp.SetMostSigOp(*op1);
-    }
-    if (op2) {
-        exp.SetLeastSigOp(*op2);
-    }
-}
-
 auto processOp(std::stack<std::string>& ops, std::stack<std::unique_ptr<Oasis::Expression>>& st) -> Oasis::FromInFixResult
 {
     if (st.size() < 2) {
@@ -61,30 +50,26 @@ auto processOp(std::stack<std::string>& ops, std::stack<std::unique_ptr<Oasis::E
     std::unique_ptr<Oasis::Expression> opExp;
 
     switch (op) {
-    case '+': {
-        Oasis::Add add { *left, *right };
-        opExp = add.Copy();
-    } break;
-    case '-': {
-        Oasis::Subtract subtract { *left, *right };
-        opExp = subtract.Copy();
-    } break;
-    case '*': {
-        Oasis::Multiply multiply { *left, *right };
-        opExp = multiply.Copy();
-    } break;
-    case '/': {
-        Oasis::Divide divide { *left, *right };
-        opExp = divide.Copy();
-    } break;
-    case '^': {
-        Oasis::Exponent exponent { *left, *right };
-        opExp = exponent.Copy();
+    case '+':
+        opExp = Oasis::Add{ *left, *right }.Copy();
         break;
-    }
+    case '-':
+        opExp = Oasis::Subtract{ *left, *right }.Copy();
+        break;
+    case '*':
+        opExp = Oasis::Multiply{ *left, *right }.Copy();
+        break;
+    case '/':
+        opExp = Oasis::Divide{ *left, *right }.Copy();
+        break;
+    case '^':
+        opExp = Oasis::Exponent{ *left, *right }.Copy();
+        break;
     default:
-        if (op == '(' || op == ')') return std::unexpected { "Mismatched parenthesis" };
-        return std::unexpected { std::format(R"(Unknown operator: "{}")", op) };
+        if (op == '(' || op == ')')
+            return std::unexpected{ "Mismatched parenthesis" };
+
+        return std::unexpected{ std::format(R"(Unknown operator: "{}")", op) };
     }
 
     ops.pop();
@@ -105,21 +90,11 @@ auto processFunction(std::stack<std::unique_ptr<Oasis::Expression>>& st, const s
 
     std::unique_ptr<Oasis::Expression> func;
 
-    if (function_token == "log") {
-        Oasis::Log<> log { *first_operand, *second_operand };
-        func = log.Copy();
-    } else if (function_token == "dd") {
-        Oasis::Derivative<> dd { *first_operand, *second_operand };
-        func = dd.Copy();
-    } else if (function_token == "in") {
-        Oasis::Integral<> in;
-        setOps(in, first_operand, second_operand);
-        func = in.Copy();
-    } else {
-        return std::unexpected { std::format(R"(Unknown function: "{}")", function_token) };
-    }
-
-    return func;
+    if (function_token == "log") return Oasis::Log { *first_operand, *second_operand }.Copy();
+    if (function_token == "dd") return Oasis::Derivative{ *first_operand, *second_operand }.Copy();
+    if (function_token == "in") return Oasis::Integral { *first_operand, *second_operand }.Copy();
+    
+    return std::unexpected { std::format(R"(Unknown function: "{}")", function_token) };
 }
 
 template <typename First, typename... T>

--- a/io/src/FromString.cpp
+++ b/io/src/FromString.cpp
@@ -262,7 +262,7 @@ auto FromInFix(const std::string& str, ParseImaginaryOption option) -> std::expe
     std::stack<std::variant<Operator, Function, OpenParens>> ops;
 
     std::string token;
-    std::stringstream ss{ str };
+    std::stringstream ss { str };
 
     while (ss >> token) {
         // Operand
@@ -276,7 +276,7 @@ auto FromInFix(const std::string& str, ParseImaginaryOption option) -> std::expe
             while (!ops.empty() && prec(ops.top()) >= prec(newOp.value())) {
                 auto processOpResult = processOp(ops, st);
                 if (!processOpResult)
-                    return std::unexpected{ processOpResult.error() };
+                    return std::unexpected { processOpResult.error() };
                 st.emplace(std::move(processOpResult.value()));
             }
             ops.emplace(newOp.value());
@@ -315,8 +315,7 @@ auto FromInFix(const std::string& str, ParseImaginaryOption option) -> std::expe
                     return std::unexpected { processFunctionResult.error() };
                 st.emplace(std::move(processFunctionResult.value()));
             }
-        }
-        else if (ss.peek() != '(') {
+        } else if (ss.peek() != '(') {
             st.push(ParseOperand(token, option));
         }
     }

--- a/io/src/InFixSerializer.cpp
+++ b/io/src/InFixSerializer.cpp
@@ -23,7 +23,7 @@ namespace Oasis {
 
 auto InFixSerializer::TypedVisit(const Real& real) -> RetT
 {
-    return std::expected<std::string, std::string_view> { std::format("{:.5}", real.GetValue()) };
+    return std::format("{:.5}", real.GetValue());
 }
 
 auto InFixSerializer::TypedVisit(const Imaginary&) -> RetT

--- a/io/src/InFixSerializer.cpp
+++ b/io/src/InFixSerializer.cpp
@@ -68,7 +68,7 @@ auto InFixSerializer::TypedVisit(const Exponent<>& exponent) -> RetT
 
 auto InFixSerializer::TypedVisit(const Log<>& log) -> RetT
 {
-    return SerializeArithBinExp(log, "log");
+    return SerializeFuncBinExp(log, "log");
 }
 
 auto InFixSerializer::TypedVisit(const Negate<Expression>& negate) -> RetT

--- a/io/src/TeXSerializer.cpp
+++ b/io/src/TeXSerializer.cpp
@@ -155,7 +155,7 @@ auto TeXSerializer::TypedVisit(const Multiply<Expression, Expression>& multiply)
 
 auto TeXSerializer::TypedVisit(const Divide<Expression, Expression>& divide) -> RetT
 {
-    return GetOpsOfBinExp(divide).and_then([this](const auto& ops) -> std::expected<std::string, std::string_view> {
+    return GetOpsOfBinExp(divide).and_then([this](const auto& ops) -> RetT {
         const auto& [mostSigOpStr, leastSigOpStr] = ops;
         if (latexOptions.divType == TeXOpts::DivType::DIV)
             return std::format("\\left({{{}}}\\div{{{}}}\\right)", mostSigOpStr, leastSigOpStr);


### PR DESCRIPTION
This pull request introduces several significant changes to the build configuration and adds a new CLI executable. The most important changes include enabling the building of the CLI and IO components conditionally, adding dependencies for the CLI, and implementing the CLI's main functionality.

### Build Configuration Changes:
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR20-R23): Enabled `OASIS_BUILD_IO` when `OASIS_BUILD_CLI` is set, included `FetchTinyxml2.cmake` conditionally based on `OASIS_BUILD_IO`, and added dependencies for `OASIS_BUILD_CLI` including `FetchLinenoise.cmake` and `fmt` library. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR20-R23) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL37-R48) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR63-R75)

### CLI Implementation:
* [`cli/CMakeLists.txt`](diffhunk://#diff-c5c3bdd00b56a091c6aed590eeb1ce30fc7709838595cb14d0e93135bd852640R1-R3): Added a new executable target `OasisCLI` with dependencies on `Oasis`, `IO`, `Linenoise`, and `fmt`.
* [`cli/main.cpp`](diffhunk://#diff-75463708a4f8d57e41d9fbbacae91b7296d154c043da7f56ab78b21f8261052eR1-R49): Implemented the main functionality of the CLI, including command history, input parsing, and error handling using `linenoise` and `fmt` libraries.

### New Dependencies:
* [`cmake/FetchLinenoise.cmake`](diffhunk://#diff-33e917afa283840aca0b6ed0cbd0f33c2292d37de52bc8a3e73350bd7f1fed12R1-R12): Added the `linenoise` library as a dependency for the CLI.

### Code Refactoring:
* [`io/src/InFixSerializer.cpp`](diffhunk://#diff-313e7d56aaedc4128efa372ee9575817a6e7b5f594ffbef17c036b4e6f233db0L71-R71): Refactored the `TypedVisit` method for the `Log` class to use `SerializeFuncBinExp` instead of `SerializeArithBinExp`.