### PR TITLE
Correct result handling in CLI output formatting.

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -63,7 +63,9 @@ int main(int argc, char** argv)
                               return expr->Accept(serializer);
                           });
 
-        fmt::println("  {}", fmt::styled(result.value_or(result.error()), result.has_value() ? success_style : err_style));
+        if (result.has_value()) fmt::println("  {}", fmt::styled(result.value(), success_style));
+        else fmt::println("  {}", fmt::styled(result.error(), err_style));
+
         std::fflush(stdout);
     }
 

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -63,8 +63,10 @@ int main(int argc, char** argv)
                               return expr->Accept(serializer);
                           });
 
-        if (result.has_value()) fmt::println("  {}", fmt::styled(result.value(), success_style));
-        else fmt::println("  {}", fmt::styled(result.error(), err_style));
+        if (result.has_value())
+            fmt::println("  {}", fmt::styled(result.value(), success_style));
+        else
+            fmt::println("  {}", fmt::styled(result.error(), err_style));
 
         std::fflush(stdout);
     }


### PR DESCRIPTION
This pull request includes a small change to the `cli/main.cpp` file. The change improves the handling of the `result` variable in the `main` function by using an `if-else` statement to separately handle the success and error cases, which enhances code readability and correctness.

* [`cli/main.cpp`](diffhunk://#diff-75463708a4f8d57e41d9fbbacae91b7296d154c043da7f56ab78b21f8261052eL66-R68): Improved handling of `result` variable in the `main` function by using an `if-else` statement to separately handle success and error cases.