### PR TITLE
Replace Unicode with HTML entity for integral symbol in MathML

### DIFF
--- a/io/src/MathMLSerializer.cpp
+++ b/io/src/MathMLSerializer.cpp
@@ -383,7 +383,7 @@ auto MathMLSerializer::TypedVisit(const Integral<>& integral) -> RetT
 
         // Integral symbol
         tinyxml2::XMLElement* inte = doc.NewElement("mo");
-        inte->SetText(u8"\u222B");
+        inte->SetText("&int;");
 
         tinyxml2::XMLElement* dNode = doc.NewElement("mo");
         dNode->SetText("d");


### PR DESCRIPTION
Replaced the Unicode character for the integral symbol with its HTML entity (`&int;`) to improve MathML parser compatibility and output readability. This update ensures alignment with MathML serialization standards.