### PR TITLE
Use HTML entity for integral symbol in MathML output

### DIFF
--- a/io/src/MathMLSerializer.cpp
+++ b/io/src/MathMLSerializer.cpp
@@ -383,7 +383,7 @@ auto MathMLSerializer::TypedVisit(const Integral<>& integral) -> RetT
 
         // Integral symbol
         tinyxml2::XMLElement* inte = doc.NewElement("mo");
-        inte->SetText(u8"\u222B");
+        inte->SetText("&int;");
 
         tinyxml2::XMLElement* dNode = doc.NewElement("mo");
         dNode->SetText("d");


### PR DESCRIPTION
 Replaced the Unicode character for the integral symbol with its corresponding HTML entity ("&int;") to ensure compatibility with MathML parsers and improve readability in the output. This change aligns the serialization with standard MathML practices. Also happens to fix encoding issues with Embind