### PR TITLE
Add MathML serialization and tests for integrals

### DIFF
--- a/bindings/js/tests/index.ts
+++ b/bindings/js/tests/index.ts
@@ -9,3 +9,18 @@ test("Addition of Real Numbers", async () => {
     const addResultStr = Oasis.ToMathMLString(addResult);
     assert.equal(addResultStr, "<mn>4</mn>\n");
 });
+
+test("Parsing and Serializing of Integrals", async () => {
+    const Oasis = await loadOasis();
+    const integral = Oasis.FromInFix("in ( 1 , x )");
+    const integralML = Oasis.ToMathMLString(integral);
+    assert.equal(integralML, `<mrow>
+    <mo>∫</mo>
+    <mn>1</mn>
+    <mrow>
+        <mo>d</mo>
+        <mi>x</mi>
+    </mrow>
+</mrow>
+`);
+});

--- a/io/src/MathMLSerializer.cpp
+++ b/io/src/MathMLSerializer.cpp
@@ -383,7 +383,7 @@ auto MathMLSerializer::TypedVisit(const Integral<>& integral) -> RetT
 
         // Integral symbol
         tinyxml2::XMLElement* inte = doc.NewElement("mo");
-        inte->SetText("&int;");
+        inte->SetText(reinterpret_cast<const char *>(u8"\u222B"));
 
         tinyxml2::XMLElement* dNode = doc.NewElement("mo");
         dNode->SetText("d");

--- a/io/tests/MathMLTests.cpp
+++ b/io/tests/MathMLTests.cpp
@@ -2,6 +2,7 @@
 
 #include "Oasis/Add.hpp"
 #include "Oasis/Divide.hpp"
+#include "Oasis/Integral.hpp"
 #include "Oasis/Multiply.hpp"
 #include "Oasis/Matrix.hpp"
 #include "Oasis/Variable.hpp"
@@ -238,14 +239,33 @@ TEST_CASE("Matrix to MathML 3x2", "[Matrix][MathML]")
     // std::cout<<mathml<<std::endl;
     REQUIRE(expected == mathml);
 }
-//
-//TEST_CASE("Test Magnitude", "[Magnitude]")
-//{
-//    Oasis::Magnitude m{Oasis::Real{-5}};
-//
-//    tinyxml2::XMLDocument doc;
-//    Oasis::MathMLSerializer serializer(doc);
-//
-//    m.Serialize(serializer);
-//
-//}
+
+TEST_CASE("Integral works", "[Integral][MathML]")
+{
+    Oasis::Integral in {
+        Oasis::Real { 1 },
+        Oasis::Variable { "x" }
+    };
+
+
+    tinyxml2::XMLDocument doc;
+    Oasis::MathMLSerializer serializer(doc);
+    doc.InsertEndChild(in.Accept(serializer).value());
+
+    tinyxml2::XMLPrinter printer;
+    doc.Print(&printer);
+
+    std::string mathml { printer.CStr() };
+
+    std::string expected = reinterpret_cast<const char*>(u8R"(<mrow>
+    <mo>∫</mo>
+    <mn>1</mn>
+    <mrow>
+        <mo>d</mo>
+        <mi>x</mi>
+    </mrow>
+</mrow>
+)");
+
+    REQUIRE(expected == mathml);
+}


### PR DESCRIPTION
### Description

This pull request introduces functionality and tests related to the MathML serialization of integrals. Key changes include:

- Added support for serializing integral expressions in the `MathMLSerializer`, ensuring proper use of Unicode symbols.
- Introduced test cases to verify both parsing and serialization of integrals, validating the correctness of MathML string outputs.

### Checklist

- [ ] Unit tests added/updated  
- [ ] Documentation added/